### PR TITLE
Update polars comparators to ignore null values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "coola"
-version = "0.1.2a1"
+version = "0.1.2a2"
 description = "A library to check if two complex/nested objects are equal or not"
 readme = "README.md"
 authors = ["Thibaut Durand <durand.tibo+gh@gmail.com>"]

--- a/src/coola/comparators/polars_.py
+++ b/src/coola/comparators/polars_.py
@@ -69,8 +69,6 @@ class DataFrameAllCloseOperator(BaseAllCloseOperator[DataFrame]):
             object_equal = True
         except AssertionError:
             object_equal = False
-        if not equal_nan and object_equal:
-            object_equal = object1.null_count().sum(axis=1).to_list()[0] == 0
         if show_difference and not object_equal:
             logger.info(
                 f"polars.DataFrames are different\nobject1=\n{object1}\nobject2=\n{object2}"
@@ -79,13 +77,7 @@ class DataFrameAllCloseOperator(BaseAllCloseOperator[DataFrame]):
 
 
 class DataFrameEqualityOperator(BaseEqualityOperator[DataFrame]):
-    r"""Implements an equality operator for ``polars.DataFrame``.
-
-    Args:
-    ----
-        nulls_compare_equal (bool, optional): If ``True``, null values
-            (e.g. NaN or NaT) compare as true. Default: ``False``
-    """
+    r"""Implements an equality operator for ``polars.DataFrame``."""
 
     def __init__(self) -> None:
         check_polars()
@@ -143,8 +135,6 @@ class DataFrameEqualityOperator(BaseEqualityOperator[DataFrame]):
             object_equal = True
         except AssertionError:
             object_equal = False
-        if object_equal:
-            object_equal = df1.null_count().sum(axis=1).to_list()[0] == 0
         return object_equal
 
 
@@ -189,8 +179,6 @@ class SeriesAllCloseOperator(BaseAllCloseOperator[Series]):
             object_equal = True
         except AssertionError:
             object_equal = False
-        if not equal_nan and object_equal:
-            object_equal = not object1.is_null().any()
         if show_difference and not object_equal:
             logger.info(f"polars.Series are different\nobject1=\n{object1}\nobject2=\n{object2}")
         return object_equal
@@ -253,8 +241,6 @@ class SeriesEqualityOperator(BaseEqualityOperator[Series]):
             object_equal = True
         except AssertionError:
             object_equal = False
-        if object_equal:
-            object_equal = not series1.is_null().any()
         return object_equal
 
 

--- a/tests/unit/comparators/test_polars.py
+++ b/tests/unit/comparators/test_polars.py
@@ -302,19 +302,6 @@ def test_dataframe_allclose_operator_allclose_false_nan() -> None:
 
 
 @polars_available
-def test_dataframe_allclose_operator_allclose_false_nat() -> None:
-    assert not DataFrameAllCloseOperator().allclose(
-        AllCloseTester(),
-        polars.DataFrame(
-            {"col": polars.Series(["2020/10/12", "2021/3/14", "2022/4/14", None]).str.to_datetime()}
-        ),
-        polars.DataFrame(
-            {"col": polars.Series(["2020/10/12", "2021/3/14", "2022/4/14", None]).str.to_datetime()}
-        ),
-    )
-
-
-@polars_available
 def test_dataframe_allclose_operator_allclose_true_nat() -> None:
     assert DataFrameAllCloseOperator().allclose(
         AllCloseTester(),
@@ -324,16 +311,6 @@ def test_dataframe_allclose_operator_allclose_true_nat() -> None:
         polars.DataFrame(
             {"col": polars.Series(["2020/10/12", "2021/3/14", "2022/4/14", None]).str.to_datetime()}
         ),
-        equal_nan=True,
-    )
-
-
-@polars_available
-def test_dataframe_allclose_operator_allclose_false_none_str() -> None:
-    assert not DataFrameAllCloseOperator().allclose(
-        AllCloseTester(),
-        polars.DataFrame({"col": ["a", "b", "c", "d", "e", None]}),
-        polars.DataFrame({"col": ["a", "b", "c", "d", "e", None]}),
     )
 
 
@@ -343,16 +320,6 @@ def test_dataframe_allclose_operator_allclose_true_none_str() -> None:
         AllCloseTester(),
         polars.DataFrame({"col": ["a", "b", "c", "d", "e", None]}),
         polars.DataFrame({"col": ["a", "b", "c", "d", "e", None]}),
-        equal_nan=True,
-    )
-
-
-@polars_available
-def test_dataframe_allclose_operator_allclose_false_none_int() -> None:
-    assert not DataFrameAllCloseOperator().allclose(
-        AllCloseTester(),
-        polars.DataFrame({"col": [1, 2, 3, 4, 5, None]}),
-        polars.DataFrame({"col": [1, 2, 3, 4, 5, None]}),
     )
 
 
@@ -362,7 +329,6 @@ def test_dataframe_allclose_operator_allclose_true_none_int() -> None:
         AllCloseTester(),
         polars.DataFrame({"col": [1, 2, 3, 4, 5, None]}),
         polars.DataFrame({"col": [1, 2, 3, 4, 5, None]}),
-        equal_nan=True,
     )
 
 
@@ -824,8 +790,8 @@ def test_dataframe_equality_operator_equal_false_nan() -> None:
 
 
 @polars_available
-def test_dataframe_equality_operator_equal_false_nat() -> None:
-    assert not DataFrameEqualityOperator().equal(
+def test_dataframe_equality_operator_equal_true_nat() -> None:
+    assert DataFrameEqualityOperator().equal(
         EqualityTester(),
         polars.DataFrame(
             {"col": polars.Series(["2020/10/12", "2021/3/14", "2022/4/14", None]).str.to_datetime()}
@@ -837,8 +803,8 @@ def test_dataframe_equality_operator_equal_false_nat() -> None:
 
 
 @polars_available
-def test_dataframe_equality_operator_equal_false_none_str() -> None:
-    assert not DataFrameEqualityOperator().equal(
+def test_dataframe_equality_operator_equal_true_none_str() -> None:
+    assert DataFrameEqualityOperator().equal(
         EqualityTester(),
         polars.DataFrame({"col": ["a", "b", "c", "d", "e", None]}),
         polars.DataFrame({"col": ["a", "b", "c", "d", "e", None]}),
@@ -846,8 +812,8 @@ def test_dataframe_equality_operator_equal_false_none_str() -> None:
 
 
 @polars_available
-def test_dataframe_equality_operator_equal_false_none_int() -> None:
-    assert not DataFrameEqualityOperator().equal(
+def test_dataframe_equality_operator_equal_true_none_int() -> None:
+    assert DataFrameEqualityOperator().equal(
         EqualityTester(),
         polars.DataFrame({"col": [1, 2, 3, 4, 5, None]}),
         polars.DataFrame({"col": [1, 2, 3, 4, 5, None]}),
@@ -1042,30 +1008,11 @@ def test_series_allclose_operator_allclose_true_nan() -> None:
 
 
 @polars_available
-def test_series_allclose_operator_allclose_false_nat() -> None:
-    assert not SeriesAllCloseOperator().allclose(
-        AllCloseTester(),
-        polars.Series(["2020/10/12", "2021/3/14", "2022/4/14", None]).str.to_datetime(),
-        polars.Series(["2020/10/12", "2021/3/14", "2022/4/14", None]).str.to_datetime(),
-    )
-
-
-@polars_available
 def test_series_allclose_operator_allclose_true_nat() -> None:
     assert SeriesAllCloseOperator().allclose(
         AllCloseTester(),
         polars.Series(["2020/10/12", "2021/3/14", "2022/4/14", None]).str.to_datetime(),
         polars.Series(["2020/10/12", "2021/3/14", "2022/4/14", None]).str.to_datetime(),
-        equal_nan=True,
-    )
-
-
-@polars_available
-def test_series_allclose_operator_allclose_false_none() -> None:
-    assert not SeriesAllCloseOperator().allclose(
-        AllCloseTester(),
-        polars.Series(["a", "b", "c", "d", "e", None]),
-        polars.Series(["a", "b", "c", "d", "e", None]),
     )
 
 
@@ -1075,7 +1022,6 @@ def test_series_allclose_operator_allclose_true_none() -> None:
         AllCloseTester(),
         polars.Series(["a", "b", "c", "d", "e", None]),
         polars.Series(["a", "b", "c", "d", "e", None]),
-        equal_nan=True,
     )
 
 
@@ -1263,8 +1209,8 @@ def test_series_equality_operator_equal_false_nan() -> None:
 
 
 @polars_available
-def test_series_equality_operator_equal_false_nat() -> None:
-    assert not SeriesEqualityOperator().equal(
+def test_series_equality_operator_equal_true_nat() -> None:
+    assert SeriesEqualityOperator().equal(
         EqualityTester(),
         polars.Series(["2020/10/12", "2021/3/14", "2022/4/14", None]).str.to_datetime(),
         polars.Series(["2020/10/12", "2021/3/14", "2022/4/14", None]).str.to_datetime(),
@@ -1272,8 +1218,8 @@ def test_series_equality_operator_equal_false_nat() -> None:
 
 
 @polars_available
-def test_series_equality_operator_equal_false_none() -> None:
-    assert not SeriesEqualityOperator().equal(
+def test_series_equality_operator_equal_true_none() -> None:
+    assert SeriesEqualityOperator().equal(
         EqualityTester(),
         polars.Series(["a", "b", "c", "d", "e", None]),
         polars.Series(["a", "b", "c", "d", "e", None]),


### PR DESCRIPTION
In `polars=0.20`, the default behaviour is that null values are equals.