### PR TITLE
[BC] Rename to `actual` and `expected`

### DIFF
--- a/.github/workflows/nightly-package.yaml
+++ b/.github/workflows/nightly-package.yaml
@@ -245,7 +245,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         python-version: [ '3.12', '3.11', '3.10', '3.9' ]
-        polars-version: [ '0.20.12', '0.19.19', '0.18.15' ]
+        polars-version: [ '0.20.10', '0.19.19', '0.18.15' ]
 
     steps:
       - name: Checkout

--- a/.github/workflows/nightly-package.yaml
+++ b/.github/workflows/nightly-package.yaml
@@ -245,7 +245,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         python-version: [ '3.12', '3.11', '3.10', '3.9' ]
-        polars-version: [ '0.20.11', '0.19.19', '0.18.15' ]
+        polars-version: [ '0.20.12', '0.19.19', '0.18.15' ]
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-deps.yaml
+++ b/.github/workflows/test-deps.yaml
@@ -168,7 +168,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         python-version: [ '3.12', '3.11', '3.10', '3.9' ]
-        polars-version: [ '0.20.11', '0.19.19', '0.18.15' ]
+        polars-version: [ '0.20.12', '0.19.19', '0.18.15' ]
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-deps.yaml
+++ b/.github/workflows/test-deps.yaml
@@ -168,7 +168,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         python-version: [ '3.12', '3.11', '3.10', '3.9' ]
-        polars-version: [ '0.20.12', '0.19.19', '0.18.15' ]
+        polars-version: [ '0.20.10', '0.19.19', '0.18.15' ]
 
     steps:
       - name: Checkout

--- a/docs/docs/customization.md
+++ b/docs/docs/customization.md
@@ -16,8 +16,8 @@ The following example shows how to use a custom `BaseEqualityTester`.
 >>> from coola.equality import EqualityConfig
 >>> from coola.equality.testers import BaseEqualityTester
 >>> class MyCustomEqualityTester(BaseEqualityTester):
-...     def equal(self, object1: Any, object2: Any, config: EqualityConfig) -> bool:
-...         return object1 is object2
+...     def equal(self, actual: Any, expected: Any, config: EqualityConfig) -> bool:
+...         return actual is expected
 ...
 >>> objects_are_equal([1, 2, 3], (1, 2, 3), tester=MyCustomEqualityTester())
 False
@@ -91,11 +91,11 @@ Then, you need to add the `BaseEqualityComparator` to `EqualityTester`.
 ...     def clone(self) -> "MyCustomStrEqualityOperator":
 ...         return self.__class__()
 ...
-...     def equal(self, object1: str, object2: Any, config: EqualityConfig) -> bool:
+...     def equal(self, actual: str, expected: Any, config: EqualityConfig) -> bool:
 ...         # You can add code to check the type and to log a message to indicate
 ...         # the difference between the objects if any. To keep this example
 ...         # simple, this part is skipped.
-...         return object1 in object2
+...         return actual in expected
 ...
 >>> # Step 2: add the new equality comparator to EqualityTester
 >>> tester = EqualityTester.local_copy()
@@ -129,11 +129,11 @@ the new equality comparator is added.
 ...     def clone(self) -> "MyCustomMappingEqualityComparator":
 ...         return self.__class__()
 ...
-...     def equal(self, object1: Mapping, object2: Any, config: EqualityConfig) -> bool:
+...     def equal(self, actual: Mapping, expected: Any, config: EqualityConfig) -> bool:
 ...         # You can add code to check the type and to log a message to indicate
 ...         # the difference between the objects if any. To keep this example
 ...         # simple, this part is skipped.
-...         return object1 is object2
+...         return actual is expected
 ...
 >>> tester = EqualityTester.local_copy()
 >>> tester.add_comparator(

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -62,10 +62,10 @@ False
 
 ```textmate
 INFO:coola.comparators.torch_:torch.Tensors are different
-object1=
+actual=
 tensor([[1., 1., 1.],
         [1., 1., 1.]])
-object2=
+expected=
 tensor([[0., 0., 0.],
         [0., 0., 0.]])
 INFO:coola.comparators.equality:The mappings have a different value for the key 'torch':
@@ -245,10 +245,10 @@ False
 
 ```textmate
 INFO:coola.comparators.torch_:torch.Tensors are different
-object1=
+actual=
 tensor([[1., 1., 1.],
         [1., 1., 1.]])
-object2=
+expected=
 tensor([[1.0001, 1.0001, 1.0001],
         [1.0001, 1.0001, 1.0001]])
 INFO:coola.comparators.allclose:The mappings have a different value for the key torch:

--- a/docs/docs/types.md
+++ b/docs/docs/types.md
@@ -25,7 +25,7 @@ The current supported types are:
 By default, two objects are equal if:
 
 - they have the same type
-- they are equal i.e. `object1 == object2` returns `True`
+- they are equal i.e. `actual == expected` returns `True`
 
 **Example**
 
@@ -306,7 +306,7 @@ The tolerance is only used for numbers (see below).
 By default, two objects are equal if:
 
 - they have the same type
-- they are equal i.e. `object1 == object2` returns `True`
+- they are equal i.e. `actual == expected` returns `True`
 
 **Example**
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -740,13 +740,13 @@ mkdocs = ">=1.1"
 
 [[package]]
 name = "mkdocs-material"
-version = "9.5.11"
+version = "9.5.12"
 description = "Documentation that simply works"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocs_material-9.5.11-py3-none-any.whl", hash = "sha256:788ee0f3e036dca2dc20298d65e480297d348a44c9d7b2ee05c5262983e66072"},
-    {file = "mkdocs_material-9.5.11.tar.gz", hash = "sha256:7af7f8af0dea16175558f3fb9245d26c83a17199baa5f157755e63d7437bf971"},
+    {file = "mkdocs_material-9.5.12-py3-none-any.whl", hash = "sha256:d6f0c269f015e48c76291cdc79efb70f7b33bbbf42d649cfe475522ebee61b1f"},
+    {file = "mkdocs_material-9.5.12.tar.gz", hash = "sha256:5f69cef6a8aaa4050b812f72b1094fda3d079b9a51cf27a247244c03ec455e97"},
 ]
 
 [package.dependencies]
@@ -1260,17 +1260,17 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "polars"
-version = "0.20.11"
+version = "0.20.12"
 description = "Blazingly fast DataFrame library"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "polars-0.20.11-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:3d8a3fc5ca29daea730806eaac2625446b1a448cf99c2162eef22c9f6d645b52"},
-    {file = "polars-0.20.11-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:ebc75002068308d9bc4242437332c4a91e0c56dee4844952208e481e7bc81db6"},
-    {file = "polars-0.20.11-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2f8664b0ea1a4e0cfb9594e09b6253078c1d216f1620345ba46b7354af605b0"},
-    {file = "polars-0.20.11-cp38-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:3a78f2a142dbb654c9cc06a99a7c327f881bffc71012c7d9a2c6cd1a0fb228b7"},
-    {file = "polars-0.20.11-cp38-abi3-win_amd64.whl", hash = "sha256:ab742ebb9623a24626c829a58174d2f70e2e9996a3e3449c2c655a978dfc9e34"},
-    {file = "polars-0.20.11.tar.gz", hash = "sha256:7a0b1a566c31925475815aadb4280048aeba740141dd1fe5d673e7621b9a758a"},
+    {file = "polars-0.20.12-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d3f2d41179de7284e5d27de4d809100f95a15de2ced50d750cf8800468589ff4"},
+    {file = "polars-0.20.12-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:db31580c35a60310381601ace3f0278ebb00674ce28c45a7131271f26ab1acc9"},
+    {file = "polars-0.20.12-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8767f8fc871b15b293593cccff3b44f837ded2b254813394bb29ac4ae6bdbfe9"},
+    {file = "polars-0.20.12-cp38-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:ecde9b8d070432920707c04da6a3c6bdf1d984a5854e11d3c79c2c0f8072f684"},
+    {file = "polars-0.20.12-cp38-abi3-win_amd64.whl", hash = "sha256:58fd7076fc93ca38b83f7d8aa9d1a16f8560b39ba79f757dc6f5474b9e7a0ec0"},
+    {file = "polars-0.20.12.tar.gz", hash = "sha256:f0bf4389c1a46db08d2b2b919b633c87fb08ec9c3c1c9436adc1fe80f0ff21ca"},
 ]
 
 [package.extras]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1260,17 +1260,17 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "polars"
-version = "0.20.12"
+version = "0.20.10"
 description = "Blazingly fast DataFrame library"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "polars-0.20.12-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d3f2d41179de7284e5d27de4d809100f95a15de2ced50d750cf8800468589ff4"},
-    {file = "polars-0.20.12-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:db31580c35a60310381601ace3f0278ebb00674ce28c45a7131271f26ab1acc9"},
-    {file = "polars-0.20.12-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8767f8fc871b15b293593cccff3b44f837ded2b254813394bb29ac4ae6bdbfe9"},
-    {file = "polars-0.20.12-cp38-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:ecde9b8d070432920707c04da6a3c6bdf1d984a5854e11d3c79c2c0f8072f684"},
-    {file = "polars-0.20.12-cp38-abi3-win_amd64.whl", hash = "sha256:58fd7076fc93ca38b83f7d8aa9d1a16f8560b39ba79f757dc6f5474b9e7a0ec0"},
-    {file = "polars-0.20.12.tar.gz", hash = "sha256:f0bf4389c1a46db08d2b2b919b633c87fb08ec9c3c1c9436adc1fe80f0ff21ca"},
+    {file = "polars-0.20.10-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:14b126dbe626c8df34a9cc1449dea270dbafd64deff88fc3620046e69e06f84c"},
+    {file = "polars-0.20.10-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:6d5f485dba006aa1ce443980b351a5cb8ff481cbbc51343debfbf66fb9594269"},
+    {file = "polars-0.20.10-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff934fe816856db7b72565b35abf1656db485772cd3bc5631071cef7ec1d10c7"},
+    {file = "polars-0.20.10-cp38-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:f5b7222ca39a4cbd286d9927d4924d2bc2ce6d7fc83a256bfd20b4199482722f"},
+    {file = "polars-0.20.10-cp38-abi3-win_amd64.whl", hash = "sha256:082a22c0c1bfa1fe0c24198e646ffb19478b893f594ecf8e330c7cdc136f6e6b"},
+    {file = "polars-0.20.10.tar.gz", hash = "sha256:ab32a232916df61c9377edcb5893d0b1624d810444d8fa627f9885d33819a8b7"},
 ]
 
 [package.extras]
@@ -2029,4 +2029,4 @@ all = ["jax", "jaxlib", "numpy", "pandas", "polars", "torch", "xarray"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "2322a4bd228b009d5a912a33c6bc9cf75d2d7b9984edaaa0cfc1c7a5d1512881"
+content-hash = "086084dc320f6b46ef75aaf5f0bcd05dc30708bf03855c7472a80e5b3706b0d9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ jaxlib = { version = ">=0.4.1,<1.0", optional = true }
 numpy = { version = ">=1.21,<2.0", optional = true }
 pandas = { version = ">=1.3,<3.0", optional = true }
 # polars: 0.18.3 is the minimal version because of https://github.com/pola-rs/polars/issues/9358
-polars = { version = ">=0.18.3,<1.0", optional = true }
+polars = { version = ">=0.18.3,<1.0,!=0.20.12", optional = true }
 torch = { version = ">=1.10,<3.0", optional = true }
 xarray = { version = ">=2023.1", optional = true }
 

--- a/src/coola/comparison.py
+++ b/src/coola/comparison.py
@@ -14,8 +14,8 @@ if TYPE_CHECKING:
 
 
 def objects_are_allclose(
-    object1: Any,
-    object2: Any,
+    actual: Any,
+    expected: Any,
     *,
     rtol: float = 1e-5,
     atol: float = 1e-8,
@@ -26,8 +26,8 @@ def objects_are_allclose(
     r"""Indicate if two objects are equal within a tolerance.
 
     Args:
-        object1: Specifies the first object to compare.
-        object2: Specifies the second object to compare.
+        actual: Specifies the actual input.
+        expected: Specifies the expected input.
         rtol: Specifies the relative tolerance parameter.
         atol: Specifies the absolute tolerance parameter.
         equal_nan: If ``True``, then two ``NaN``s  will be considered
@@ -71,12 +71,12 @@ def objects_are_allclose(
     config = EqualityConfig(
         tester=tester, show_difference=show_difference, equal_nan=equal_nan, atol=atol, rtol=rtol
     )
-    return tester.equal(object1, object2, config)
+    return tester.equal(actual, expected, config)
 
 
 def objects_are_equal(
-    object1: Any,
-    object2: Any,
+    actual: Any,
+    expected: Any,
     *,
     equal_nan: bool = False,
     show_difference: bool = False,
@@ -85,8 +85,8 @@ def objects_are_equal(
     r"""Indicate if two objects are equal or not.
 
     Args:
-        object1: Specifies the first object to compare.
-        object2: Specifies the second object to compare.
+        actual: Specifies the actual input.
+        expected: Specifies the expected input.
         equal_nan: If ``True``, then two ``NaN``s  will be considered
             as equal.
         show_difference: If ``True``, it shows a difference between
@@ -116,4 +116,4 @@ def objects_are_equal(
     """
     tester = tester or EqualityTester()
     config = EqualityConfig(tester=tester, show_difference=show_difference, equal_nan=equal_nan)
-    return tester.equal(object1, object2, config)
+    return tester.equal(actual, expected, config)

--- a/src/coola/equality/comparators/base.py
+++ b/src/coola/equality/comparators/base.py
@@ -60,12 +60,12 @@ class BaseEqualityComparator(ABC, Generic[T]):
         """
 
     @abstractmethod
-    def equal(self, object1: T, object2: Any, config: EqualityConfig) -> bool:
+    def equal(self, actual: T, expected: Any, config: EqualityConfig) -> bool:
         r"""Indicate if two objects are equal or not.
 
         Args:
-            object1: Specifies the first object to compare.
-            object2: Specifies the second object to compare.
+            actual: Specifies the actual input.
+            expected: Specifies the expected input.
             config: Specifies the equality configuration.
 
         Returns:

--- a/src/coola/equality/comparators/collection.py
+++ b/src/coola/equality/comparators/collection.py
@@ -58,8 +58,8 @@ class MappingEqualityComparator(BaseEqualityComparator[Mapping]):
     def clone(self) -> MappingEqualityComparator:
         return self.__class__()
 
-    def equal(self, object1: Mapping, object2: Any, config: EqualityConfig) -> bool:
-        return self._handler.handle(object1=object1, object2=object2, config=config)
+    def equal(self, actual: Mapping, expected: Any, config: EqualityConfig) -> bool:
+        return self._handler.handle(actual=actual, expected=expected, config=config)
 
 
 class SequenceEqualityComparator(BaseEqualityComparator[Sequence]):
@@ -93,8 +93,8 @@ class SequenceEqualityComparator(BaseEqualityComparator[Sequence]):
     def clone(self) -> SequenceEqualityComparator:
         return self.__class__()
 
-    def equal(self, object1: Sequence, object2: Any, config: EqualityConfig) -> bool:
-        return self._handler.handle(object1=object1, object2=object2, config=config)
+    def equal(self, actual: Sequence, expected: Any, config: EqualityConfig) -> bool:
+        return self._handler.handle(actual=actual, expected=expected, config=config)
 
 
 def get_type_comparator_mapping() -> dict[type, BaseEqualityComparator]:

--- a/src/coola/equality/comparators/default.py
+++ b/src/coola/equality/comparators/default.py
@@ -52,8 +52,8 @@ class DefaultEqualityComparator(BaseEqualityComparator[Any]):
     def clone(self) -> DefaultEqualityComparator:
         return self.__class__()
 
-    def equal(self, object1: Any, object2: Any, config: EqualityConfig) -> bool:
-        return self._handler.handle(object1=object1, object2=object2, config=config)
+    def equal(self, actual: Any, expected: Any, config: EqualityConfig) -> bool:
+        return self._handler.handle(actual=actual, expected=expected, config=config)
 
 
 def get_type_comparator_mapping() -> dict[type, BaseEqualityComparator]:

--- a/src/coola/equality/comparators/jax_.py
+++ b/src/coola/equality/comparators/jax_.py
@@ -63,8 +63,8 @@ class JaxArrayEqualityComparator(BaseEqualityComparator[jnp.ndarray]):
     def clone(self) -> JaxArrayEqualityComparator:
         return self.__class__()
 
-    def equal(self, object1: jnp.ndarray, object2: Any, config: EqualityConfig) -> bool:
-        return self._handler.handle(object1=object1, object2=object2, config=config)
+    def equal(self, actual: jnp.ndarray, expected: Any, config: EqualityConfig) -> bool:
+        return self._handler.handle(actual=actual, expected=expected, config=config)
 
 
 def get_type_comparator_mapping() -> dict[type, BaseEqualityComparator]:

--- a/src/coola/equality/comparators/numpy_.py
+++ b/src/coola/equality/comparators/numpy_.py
@@ -69,8 +69,8 @@ class NumpyArrayEqualityComparator(BaseEqualityComparator[np.ndarray]):
     def clone(self) -> NumpyArrayEqualityComparator:
         return self.__class__()
 
-    def equal(self, object1: Any, object2: Any, config: EqualityConfig) -> bool:
-        return self._handler.handle(object1=object1, object2=object2, config=config)
+    def equal(self, actual: Any, expected: Any, config: EqualityConfig) -> bool:
+        return self._handler.handle(actual=actual, expected=expected, config=config)
 
 
 class NumpyMaskedArrayEqualityComparator(BaseEqualityComparator[np.ma.MaskedArray]):
@@ -110,8 +110,8 @@ class NumpyMaskedArrayEqualityComparator(BaseEqualityComparator[np.ma.MaskedArra
     def clone(self) -> NumpyMaskedArrayEqualityComparator:
         return self.__class__()
 
-    def equal(self, object1: np.ma.MaskedArray, object2: Any, config: EqualityConfig) -> bool:
-        return self._handler.handle(object1=object1, object2=object2, config=config)
+    def equal(self, actual: np.ma.MaskedArray, expected: Any, config: EqualityConfig) -> bool:
+        return self._handler.handle(actual=actual, expected=expected, config=config)
 
 
 def get_type_comparator_mapping() -> dict[type, BaseEqualityComparator]:

--- a/src/coola/equality/comparators/pandas_.py
+++ b/src/coola/equality/comparators/pandas_.py
@@ -72,8 +72,8 @@ class PandasDataFrameEqualityComparator(BaseEqualityComparator[pandas.DataFrame]
     def clone(self) -> PandasDataFrameEqualityComparator:
         return self.__class__()
 
-    def equal(self, object1: pandas.DataFrame, object2: Any, config: EqualityConfig) -> bool:
-        return self._handler.handle(object1=object1, object2=object2, config=config)
+    def equal(self, actual: pandas.DataFrame, expected: Any, config: EqualityConfig) -> bool:
+        return self._handler.handle(actual=actual, expected=expected, config=config)
 
 
 class PandasSeriesEqualityComparator(BaseEqualityComparator[pandas.Series]):
@@ -107,8 +107,8 @@ class PandasSeriesEqualityComparator(BaseEqualityComparator[pandas.Series]):
     def clone(self) -> PandasSeriesEqualityComparator:
         return self.__class__()
 
-    def equal(self, object1: pandas.Series, object2: Any, config: EqualityConfig) -> bool:
-        return self._handler.handle(object1=object1, object2=object2, config=config)
+    def equal(self, actual: pandas.Series, expected: Any, config: EqualityConfig) -> bool:
+        return self._handler.handle(actual=actual, expected=expected, config=config)
 
 
 def get_type_comparator_mapping() -> dict[type, BaseEqualityComparator]:

--- a/src/coola/equality/comparators/polars_.py
+++ b/src/coola/equality/comparators/polars_.py
@@ -72,8 +72,8 @@ class PolarsDataFrameEqualityComparator(BaseEqualityComparator[polars.DataFrame]
     def clone(self) -> PolarsDataFrameEqualityComparator:
         return self.__class__()
 
-    def equal(self, object1: polars.DataFrame, object2: Any, config: EqualityConfig) -> bool:
-        return self._handler.handle(object1=object1, object2=object2, config=config)
+    def equal(self, actual: polars.DataFrame, expected: Any, config: EqualityConfig) -> bool:
+        return self._handler.handle(actual=actual, expected=expected, config=config)
 
 
 class PolarsSeriesEqualityComparator(BaseEqualityComparator[polars.Series]):
@@ -107,8 +107,8 @@ class PolarsSeriesEqualityComparator(BaseEqualityComparator[polars.Series]):
     def clone(self) -> PolarsSeriesEqualityComparator:
         return self.__class__()
 
-    def equal(self, object1: polars.Series, object2: Any, config: EqualityConfig) -> bool:
-        return self._handler.handle(object1=object1, object2=object2, config=config)
+    def equal(self, actual: polars.Series, expected: Any, config: EqualityConfig) -> bool:
+        return self._handler.handle(actual=actual, expected=expected, config=config)
 
 
 def get_type_comparator_mapping() -> dict[type, BaseEqualityComparator]:

--- a/src/coola/equality/comparators/scalar.py
+++ b/src/coola/equality/comparators/scalar.py
@@ -50,8 +50,8 @@ class ScalarEqualityComparator(BaseEqualityComparator[Any]):
     def clone(self) -> ScalarEqualityComparator:
         return self.__class__()
 
-    def equal(self, object1: Any, object2: Any, config: EqualityConfig) -> bool:
-        return self._handler.handle(object1=object1, object2=object2, config=config)
+    def equal(self, actual: Any, expected: Any, config: EqualityConfig) -> bool:
+        return self._handler.handle(actual=actual, expected=expected, config=config)
 
 
 def get_type_comparator_mapping() -> dict[type, BaseEqualityComparator]:

--- a/src/coola/equality/comparators/torch_.py
+++ b/src/coola/equality/comparators/torch_.py
@@ -80,9 +80,9 @@ class TorchPackedSequenceEqualityComparator(
         return self.__class__()
 
     def equal(
-        self, object1: torch.nn.utils.rnn.PackedSequence, object2: Any, config: EqualityConfig
+        self, actual: torch.nn.utils.rnn.PackedSequence, expected: Any, config: EqualityConfig
     ) -> bool:
-        return self._handler.handle(object1=object1, object2=object2, config=config)
+        return self._handler.handle(actual=actual, expected=expected, config=config)
 
 
 class TorchTensorEqualityComparator(BaseEqualityComparator[torch.Tensor]):
@@ -118,8 +118,8 @@ class TorchTensorEqualityComparator(BaseEqualityComparator[torch.Tensor]):
     def clone(self) -> TorchTensorEqualityComparator:
         return self.__class__()
 
-    def equal(self, object1: torch.Tensor, object2: Any, config: EqualityConfig) -> bool:
-        return self._handler.handle(object1=object1, object2=object2, config=config)
+    def equal(self, actual: torch.Tensor, expected: Any, config: EqualityConfig) -> bool:
+        return self._handler.handle(actual=actual, expected=expected, config=config)
 
 
 def get_type_comparator_mapping() -> dict[type, BaseEqualityComparator]:

--- a/src/coola/equality/comparators/xarray_.py
+++ b/src/coola/equality/comparators/xarray_.py
@@ -76,8 +76,8 @@ class XarrayDataArrayEqualityComparator(BaseEqualityComparator[xr.DataArray]):
     def clone(self) -> XarrayDataArrayEqualityComparator:
         return self.__class__()
 
-    def equal(self, object1: xr.DataArray, object2: Any, config: EqualityConfig) -> bool:
-        return self._handler.handle(object1=object1, object2=object2, config=config)
+    def equal(self, actual: xr.DataArray, expected: Any, config: EqualityConfig) -> bool:
+        return self._handler.handle(actual=actual, expected=expected, config=config)
 
 
 class XarrayDatasetEqualityComparator(BaseEqualityComparator[xr.Dataset]):
@@ -122,8 +122,8 @@ class XarrayDatasetEqualityComparator(BaseEqualityComparator[xr.Dataset]):
     def clone(self) -> XarrayDatasetEqualityComparator:
         return self.__class__()
 
-    def equal(self, object1: xr.Dataset, object2: Any, config: EqualityConfig) -> bool:
-        return self._handler.handle(object1=object1, object2=object2, config=config)
+    def equal(self, actual: xr.Dataset, expected: Any, config: EqualityConfig) -> bool:
+        return self._handler.handle(actual=actual, expected=expected, config=config)
 
 
 class XarrayVariableEqualityComparator(BaseEqualityComparator[xr.Variable]):
@@ -168,8 +168,8 @@ class XarrayVariableEqualityComparator(BaseEqualityComparator[xr.Variable]):
     def clone(self) -> XarrayVariableEqualityComparator:
         return self.__class__()
 
-    def equal(self, object1: xr.Variable, object2: Any, config: EqualityConfig) -> bool:
-        return self._handler.handle(object1=object1, object2=object2, config=config)
+    def equal(self, actual: xr.Variable, expected: Any, config: EqualityConfig) -> bool:
+        return self._handler.handle(actual=actual, expected=expected, config=config)
 
 
 def get_type_comparator_mapping() -> dict[type, BaseEqualityComparator]:

--- a/src/coola/equality/handlers/base.py
+++ b/src/coola/equality/handlers/base.py
@@ -65,12 +65,12 @@ class BaseEqualityHandler(ABC):
         return handler
 
     @abstractmethod
-    def handle(self, object1: Any, object2: Any, config: EqualityConfig) -> bool:
+    def handle(self, actual: Any, expected: Any, config: EqualityConfig) -> bool:
         r"""Return the equality result between the two input objects.
 
         Args:
-            object1: Specifies the first object to compare.
-            object2: Specifies the second object to compare.
+            actual: Specifies the actual input.
+            expected: Specifies the expected input.
             config: Specifies the equality configuration.
 
         Returns:
@@ -149,7 +149,7 @@ class AbstractEqualityHandler(BaseEqualityHandler):
         if not self._next_handler:
             msg = "next handler is not defined"
             raise RuntimeError(msg)
-        return self._next_handler.handle(object1=object1, object2=object2, config=config)
+        return self._next_handler.handle(actual=object1, expected=object2, config=config)
 
     def set_next_handler(self, handler: BaseEqualityHandler) -> None:
         if not isinstance(handler, BaseEqualityHandler):

--- a/src/coola/equality/handlers/base.py
+++ b/src/coola/equality/handlers/base.py
@@ -132,12 +132,12 @@ class AbstractEqualityHandler(BaseEqualityHandler):
         """The next handler."""
         return self._next_handler
 
-    def _handle_next(self, object1: Any, object2: Any, config: EqualityConfig) -> bool:
+    def _handle_next(self, actual: Any, expected: Any, config: EqualityConfig) -> bool:
         r"""Return the output from the next handler.
 
         Args:
-            object1: Specifies the first object to compare.
-            object2: Specifies the second object to compare.
+            actual: Specifies the first object to compare.
+            expected: Specifies the second object to compare.
             config: Specifies the equality configuration.
 
         Returns:
@@ -149,7 +149,7 @@ class AbstractEqualityHandler(BaseEqualityHandler):
         if not self._next_handler:
             msg = "next handler is not defined"
             raise RuntimeError(msg)
-        return self._next_handler.handle(actual=object1, expected=object2, config=config)
+        return self._next_handler.handle(actual=actual, expected=expected, config=config)
 
     def set_next_handler(self, handler: BaseEqualityHandler) -> None:
         if not isinstance(handler, BaseEqualityHandler):

--- a/src/coola/equality/handlers/base.py
+++ b/src/coola/equality/handlers/base.py
@@ -136,8 +136,8 @@ class AbstractEqualityHandler(BaseEqualityHandler):
         r"""Return the output from the next handler.
 
         Args:
-            actual: Specifies the first object to compare.
-            expected: Specifies the second object to compare.
+            actual: Specifies the actual input.
+            expected: Specifies the expected input.
             config: Specifies the equality configuration.
 
         Returns:

--- a/src/coola/equality/handlers/data.py
+++ b/src/coola/equality/handlers/data.py
@@ -63,4 +63,4 @@ class SameDataHandler(AbstractEqualityHandler):
             if config.show_difference:
                 logger.info(f"objects have different data: {actual.data} vs {expected.data}")
             return False
-        return self._handle_next(object1=actual, object2=expected, config=config)
+        return self._handle_next(actual=actual, expected=expected, config=config)

--- a/src/coola/equality/handlers/data.py
+++ b/src/coola/equality/handlers/data.py
@@ -58,9 +58,9 @@ class SameDataHandler(AbstractEqualityHandler):
     def __eq__(self, other: object) -> bool:
         return isinstance(other, self.__class__)
 
-    def handle(self, object1: SupportsData, object2: SupportsData, config: EqualityConfig) -> bool:
-        if not config.tester.equal(object1.data, object2.data, config):
+    def handle(self, actual: SupportsData, expected: SupportsData, config: EqualityConfig) -> bool:
+        if not config.tester.equal(actual.data, expected.data, config):
             if config.show_difference:
-                logger.info(f"objects have different data: {object1.data} vs {object2.data}")
+                logger.info(f"objects have different data: {actual.data} vs {expected.data}")
             return False
-        return self._handle_next(object1=object1, object2=object2, config=config)
+        return self._handle_next(object1=actual, object2=expected, config=config)

--- a/src/coola/equality/handlers/dtype.py
+++ b/src/coola/equality/handlers/dtype.py
@@ -68,4 +68,4 @@ class SameDTypeHandler(AbstractEqualityHandler):
                     f"objects have different data types: {actual.dtype} vs {expected.dtype}"
                 )
             return False
-        return self._handle_next(object1=actual, object2=expected, config=config)
+        return self._handle_next(actual=actual, expected=expected, config=config)

--- a/src/coola/equality/handlers/dtype.py
+++ b/src/coola/equality/handlers/dtype.py
@@ -60,12 +60,12 @@ class SameDTypeHandler(AbstractEqualityHandler):
         return isinstance(other, self.__class__)
 
     def handle(
-        self, object1: SupportsDType, object2: SupportsDType, config: EqualityConfig
+        self, actual: SupportsDType, expected: SupportsDType, config: EqualityConfig
     ) -> bool:
-        if object1.dtype != object2.dtype:
+        if actual.dtype != expected.dtype:
             if config.show_difference:
                 logger.info(
-                    f"objects have different data types: {object1.dtype} vs {object2.dtype}"
+                    f"objects have different data types: {actual.dtype} vs {expected.dtype}"
                 )
             return False
-        return self._handle_next(object1=object1, object2=object2, config=config)
+        return self._handle_next(object1=actual, object2=expected, config=config)

--- a/src/coola/equality/handlers/equal.py
+++ b/src/coola/equality/handlers/equal.py
@@ -79,7 +79,7 @@ class EqualHandler(BaseEqualityHandler):
     def handle(self, actual: SupportsEqual, expected: Any, config: EqualityConfig) -> bool:
         if not actual.equal(expected, equal_nan=config.equal_nan):
             if config.show_difference:
-                logger.info(f"objects are not equal:\nobject1:\n{actual}\nobject2:\n{expected}")
+                logger.info(f"objects are not equal:\nactual:\n{actual}\nexpected:\n{expected}")
             return False
         return True
 

--- a/src/coola/equality/handlers/equal.py
+++ b/src/coola/equality/handlers/equal.py
@@ -76,10 +76,10 @@ class EqualHandler(BaseEqualityHandler):
     def __repr__(self) -> str:
         return f"{self.__class__.__qualname__}()"
 
-    def handle(self, object1: SupportsEqual, object2: Any, config: EqualityConfig) -> bool:
-        if not object1.equal(object2, equal_nan=config.equal_nan):
+    def handle(self, actual: SupportsEqual, expected: Any, config: EqualityConfig) -> bool:
+        if not actual.equal(expected, equal_nan=config.equal_nan):
             if config.show_difference:
-                logger.info(f"objects are not equal:\nobject1:\n{object1}\nobject2:\n{object2}")
+                logger.info(f"objects are not equal:\nobject1:\n{actual}\nobject2:\n{expected}")
             return False
         return True
 

--- a/src/coola/equality/handlers/jax_.py
+++ b/src/coola/equality/handlers/jax_.py
@@ -55,15 +55,15 @@ class JaxArrayEqualHandler(BaseEqualityHandler):
 
     def handle(
         self,
-        object1: jnp.ndarray,
-        object2: jnp.ndarray,
+        actual: jnp.ndarray,
+        expected: jnp.ndarray,
         config: EqualityConfig,
     ) -> bool:
-        object_equal = array_equal(object1, object2, config)
+        object_equal = array_equal(actual, expected, config)
         if config.show_difference and not object_equal:
             logger.info(
                 f"jax.numpy.ndarrays have different elements:\n"
-                f"object1=\n{object1}\nobject2=\n{object2}"
+                f"object1=\n{actual}\nobject2=\n{expected}"
             )
         return object_equal
 

--- a/src/coola/equality/handlers/jax_.py
+++ b/src/coola/equality/handlers/jax_.py
@@ -63,7 +63,7 @@ class JaxArrayEqualHandler(BaseEqualityHandler):
         if config.show_difference and not object_equal:
             logger.info(
                 f"jax.numpy.ndarrays have different elements:\n"
-                f"object1=\n{actual}\nobject2=\n{expected}"
+                f"actual=\n{actual}\nexpected=\n{expected}"
             )
         return object_equal
 

--- a/src/coola/equality/handlers/mapping.py
+++ b/src/coola/equality/handlers/mapping.py
@@ -58,7 +58,7 @@ class MappingSameKeysHandler(AbstractEqualityHandler):
                     f"additional keys: {sorted(additional_keys)}"
                 )
             return False
-        return self._handle_next(object1=actual, object2=expected, config=config)
+        return self._handle_next(actual=actual, expected=expected, config=config)
 
 
 class MappingSameValuesHandler(AbstractEqualityHandler):
@@ -102,14 +102,14 @@ class MappingSameValuesHandler(AbstractEqualityHandler):
     ) -> bool:
         for key in actual:
             if not config.tester.equal(actual[key], expected[key], config):
-                self._show_difference(object1=actual, object2=expected, config=config)
+                self._show_difference(actual=actual, expected=expected, config=config)
                 return False
-        return self._handle_next(object1=actual, object2=expected, config=config)
+        return self._handle_next(actual=actual, expected=expected, config=config)
 
-    def _show_difference(self, object1: Mapping, object2: Mapping, config: EqualityConfig) -> None:
+    def _show_difference(self, actual: Mapping, expected: Mapping, config: EqualityConfig) -> None:
         if config.show_difference:
             logger.info(
                 f"mappings have at least one different value:\n"
-                f"first mapping : {object1}\n"
-                f"second mapping: {object2}"
+                f"first mapping : {actual}\n"
+                f"second mapping: {expected}"
             )

--- a/src/coola/equality/handlers/mapping.py
+++ b/src/coola/equality/handlers/mapping.py
@@ -42,13 +42,13 @@ class MappingSameKeysHandler(AbstractEqualityHandler):
 
     def handle(
         self,
-        object1: Mapping,
-        object2: Mapping,
+        actual: Mapping,
+        expected: Mapping,
         config: EqualityConfig,
     ) -> bool:
-        keys1 = set(object1.keys())
-        keys2 = set(object2.keys())
-        if keys1 != set(object2.keys()):
+        keys1 = set(actual.keys())
+        keys2 = set(expected.keys())
+        if keys1 != set(expected.keys()):
             if config.show_difference:
                 missing_keys = keys1 - keys2
                 additional_keys = keys2 - keys1
@@ -58,7 +58,7 @@ class MappingSameKeysHandler(AbstractEqualityHandler):
                     f"additional keys: {sorted(additional_keys)}"
                 )
             return False
-        return self._handle_next(object1=object1, object2=object2, config=config)
+        return self._handle_next(object1=actual, object2=expected, config=config)
 
 
 class MappingSameValuesHandler(AbstractEqualityHandler):
@@ -96,15 +96,15 @@ class MappingSameValuesHandler(AbstractEqualityHandler):
 
     def handle(
         self,
-        object1: Mapping,
-        object2: Mapping,
+        actual: Mapping,
+        expected: Mapping,
         config: EqualityConfig,
     ) -> bool:
-        for key in object1:
-            if not config.tester.equal(object1[key], object2[key], config):
-                self._show_difference(object1=object1, object2=object2, config=config)
+        for key in actual:
+            if not config.tester.equal(actual[key], expected[key], config):
+                self._show_difference(object1=actual, object2=expected, config=config)
                 return False
-        return self._handle_next(object1=object1, object2=object2, config=config)
+        return self._handle_next(object1=actual, object2=expected, config=config)
 
     def _show_difference(self, object1: Mapping, object2: Mapping, config: EqualityConfig) -> None:
         if config.show_difference:

--- a/src/coola/equality/handlers/native.py
+++ b/src/coola/equality/handlers/native.py
@@ -145,7 +145,7 @@ class ObjectEqualHandler(BaseEqualityHandler):
     ) -> bool:
         object_equal = actual == expected
         if config.show_difference and not object_equal:
-            logger.info(f"objects are different:\nobject1={actual}\nobject2={expected}")
+            logger.info(f"objects are different:\nactual={actual}\nexpected={expected}")
         return object_equal
 
     def set_next_handler(self, handler: BaseEqualityHandler) -> None:
@@ -203,7 +203,7 @@ class SameAttributeHandler(AbstractEqualityHandler):
             if config.show_difference:
                 logger.info(f"objects have different {self._name}: {value1} vs {value2}")
             return False
-        return self._handle_next(object1=actual, object2=expected, config=config)
+        return self._handle_next(actual=actual, expected=expected, config=config)
 
 
 class SameLengthHandler(AbstractEqualityHandler):
@@ -239,7 +239,7 @@ class SameLengthHandler(AbstractEqualityHandler):
             if config.show_difference:
                 logger.info(f"objects have different lengths: {len(actual):,} vs {len(expected):,}")
             return False
-        return self._handle_next(object1=actual, object2=expected, config=config)
+        return self._handle_next(actual=actual, expected=expected, config=config)
 
 
 class SameObjectHandler(AbstractEqualityHandler):
@@ -273,7 +273,7 @@ class SameObjectHandler(AbstractEqualityHandler):
     ) -> bool | None:
         if actual is expected:
             return True
-        return self._handle_next(object1=actual, object2=expected, config=config)
+        return self._handle_next(actual=actual, expected=expected, config=config)
 
 
 class SameTypeHandler(AbstractEqualityHandler):
@@ -309,4 +309,4 @@ class SameTypeHandler(AbstractEqualityHandler):
             if config.show_difference:
                 logger.info(f"objects have different types: {type(actual)} vs {type(expected)}")
             return False
-        return self._handle_next(object1=actual, object2=expected, config=config)
+        return self._handle_next(actual=actual, expected=expected, config=config)

--- a/src/coola/equality/handlers/native.py
+++ b/src/coola/equality/handlers/native.py
@@ -56,8 +56,8 @@ class FalseHandler(BaseEqualityHandler):
 
     def handle(
         self,
-        object1: Any,
-        object2: Any,
+        actual: Any,
+        expected: Any,
         config: EqualityConfig,
     ) -> bool:
         return False
@@ -96,8 +96,8 @@ class TrueHandler(BaseEqualityHandler):
 
     def handle(
         self,
-        object1: Any,
-        object2: Any,
+        actual: Any,
+        expected: Any,
         config: EqualityConfig,
     ) -> bool:
         return True
@@ -139,13 +139,13 @@ class ObjectEqualHandler(BaseEqualityHandler):
 
     def handle(
         self,
-        object1: Any,
-        object2: Any,
+        actual: Any,
+        expected: Any,
         config: EqualityConfig,
     ) -> bool:
-        object_equal = object1 == object2
+        object_equal = actual == expected
         if config.show_difference and not object_equal:
-            logger.info(f"objects are different:\nobject1={object1}\nobject2={object2}")
+            logger.info(f"objects are different:\nobject1={actual}\nobject2={expected}")
         return object_equal
 
     def set_next_handler(self, handler: BaseEqualityHandler) -> None:
@@ -196,14 +196,14 @@ class SameAttributeHandler(AbstractEqualityHandler):
     def name(self) -> str:
         return self._name
 
-    def handle(self, object1: Any, object2: Any, config: EqualityConfig) -> bool:
-        value1 = getattr(object1, self._name)
-        value2 = getattr(object2, self._name)
+    def handle(self, actual: Any, expected: Any, config: EqualityConfig) -> bool:
+        value1 = getattr(actual, self._name)
+        value2 = getattr(expected, self._name)
         if not config.tester.equal(value1, value2, config):
             if config.show_difference:
                 logger.info(f"objects have different {self._name}: {value1} vs {value2}")
             return False
-        return self._handle_next(object1=object1, object2=object2, config=config)
+        return self._handle_next(object1=actual, object2=expected, config=config)
 
 
 class SameLengthHandler(AbstractEqualityHandler):
@@ -231,15 +231,15 @@ class SameLengthHandler(AbstractEqualityHandler):
 
     def handle(
         self,
-        object1: Sized,
-        object2: Sized,
+        actual: Sized,
+        expected: Sized,
         config: EqualityConfig,
     ) -> bool:
-        if len(object1) != len(object2):
+        if len(actual) != len(expected):
             if config.show_difference:
-                logger.info(f"objects have different lengths: {len(object1):,} vs {len(object2):,}")
+                logger.info(f"objects have different lengths: {len(actual):,} vs {len(expected):,}")
             return False
-        return self._handle_next(object1=object1, object2=object2, config=config)
+        return self._handle_next(object1=actual, object2=expected, config=config)
 
 
 class SameObjectHandler(AbstractEqualityHandler):
@@ -267,13 +267,13 @@ class SameObjectHandler(AbstractEqualityHandler):
 
     def handle(
         self,
-        object1: Any,
-        object2: Any,
+        actual: Any,
+        expected: Any,
         config: EqualityConfig,
     ) -> bool | None:
-        if object1 is object2:
+        if actual is expected:
             return True
-        return self._handle_next(object1=object1, object2=object2, config=config)
+        return self._handle_next(object1=actual, object2=expected, config=config)
 
 
 class SameTypeHandler(AbstractEqualityHandler):
@@ -301,12 +301,12 @@ class SameTypeHandler(AbstractEqualityHandler):
 
     def handle(
         self,
-        object1: Any,
-        object2: Any,
+        actual: Any,
+        expected: Any,
         config: EqualityConfig,
     ) -> bool:
-        if type(object1) is not type(object2):
+        if type(actual) is not type(expected):
             if config.show_difference:
-                logger.info(f"objects have different types: {type(object1)} vs {type(object2)}")
+                logger.info(f"objects have different types: {type(actual)} vs {type(expected)}")
             return False
-        return self._handle_next(object1=object1, object2=object2, config=config)
+        return self._handle_next(object1=actual, object2=expected, config=config)

--- a/src/coola/equality/handlers/numpy_.py
+++ b/src/coola/equality/handlers/numpy_.py
@@ -63,7 +63,7 @@ class NumpyArrayEqualHandler(BaseEqualityHandler):
         if config.show_difference and not object_equal:
             logger.info(
                 f"numpy.ndarrays have different elements:\n"
-                f"object1:\n{actual}\nobject2:\n{expected}"
+                f"actual:\n{actual}\nexpected:\n{expected}"
             )
         return object_equal
 

--- a/src/coola/equality/handlers/numpy_.py
+++ b/src/coola/equality/handlers/numpy_.py
@@ -55,15 +55,15 @@ class NumpyArrayEqualHandler(BaseEqualityHandler):
 
     def handle(
         self,
-        object1: np.ndarray,
-        object2: np.ndarray,
+        actual: np.ndarray,
+        expected: np.ndarray,
         config: EqualityConfig,
     ) -> bool:
-        object_equal = array_equal(object1, object2, config)
+        object_equal = array_equal(actual, expected, config)
         if config.show_difference and not object_equal:
             logger.info(
                 f"numpy.ndarrays have different elements:\n"
-                f"object1:\n{object1}\nobject2:\n{object2}"
+                f"object1:\n{actual}\nobject2:\n{expected}"
             )
         return object_equal
 

--- a/src/coola/equality/handlers/pandas_.py
+++ b/src/coola/equality/handlers/pandas_.py
@@ -72,7 +72,7 @@ class PandasDataFrameEqualHandler(BaseEqualityHandler):
         if config.show_difference and not object_equal:
             logger.info(
                 f"pandas.DataFrames have different elements:\n"
-                f"object1:\n{actual}\nobject2:\n{expected}"
+                f"actual:\n{actual}\nexpected:\n{expected}"
             )
         return object_equal
 
@@ -121,7 +121,7 @@ class PandasSeriesEqualHandler(BaseEqualityHandler):
         if config.show_difference and not object_equal:
             logger.info(
                 f"pandas.Series have different elements:\n"
-                f"object1:\n{actual}\nobject2:\n{expected}"
+                f"actual:\n{actual}\nexpected:\n{expected}"
             )
         return object_equal
 

--- a/src/coola/equality/handlers/pandas_.py
+++ b/src/coola/equality/handlers/pandas_.py
@@ -64,15 +64,15 @@ class PandasDataFrameEqualHandler(BaseEqualityHandler):
 
     def handle(
         self,
-        object1: pandas.DataFrame,
-        object2: pandas.DataFrame,
+        actual: pandas.DataFrame,
+        expected: pandas.DataFrame,
         config: EqualityConfig,
     ) -> bool:
-        object_equal = frame_equal(object1, object2, config)
+        object_equal = frame_equal(actual, expected, config)
         if config.show_difference and not object_equal:
             logger.info(
                 f"pandas.DataFrames have different elements:\n"
-                f"object1:\n{object1}\nobject2:\n{object2}"
+                f"object1:\n{actual}\nobject2:\n{expected}"
             )
         return object_equal
 
@@ -113,15 +113,15 @@ class PandasSeriesEqualHandler(BaseEqualityHandler):
 
     def handle(
         self,
-        object1: pandas.Series,
-        object2: pandas.Series,
+        actual: pandas.Series,
+        expected: pandas.Series,
         config: EqualityConfig,
     ) -> bool:
-        object_equal = series_equal(object1, object2, config)
+        object_equal = series_equal(actual, expected, config)
         if config.show_difference and not object_equal:
             logger.info(
                 f"pandas.Series have different elements:\n"
-                f"object1:\n{object1}\nobject2:\n{object2}"
+                f"object1:\n{actual}\nobject2:\n{expected}"
             )
         return object_equal
 

--- a/src/coola/equality/handlers/polars_.py
+++ b/src/coola/equality/handlers/polars_.py
@@ -73,7 +73,7 @@ class PolarsDataFrameEqualHandler(BaseEqualityHandler):
         if config.show_difference and not object_equal:
             logger.info(
                 f"polars.DataFrames have different elements:\n"
-                f"object1:\n{actual}\nobject2:\n{expected}"
+                f"actual:\n{actual}\nexpected:\n{expected}"
             )
         return object_equal
 
@@ -122,7 +122,7 @@ class PolarsSeriesEqualHandler(BaseEqualityHandler):
         if config.show_difference and not object_equal:
             logger.info(
                 f"polars.Series have different elements:\n"
-                f"object1:\n{actual}\nobject2:\n{expected}"
+                f"actual:\n{actual}\nexpected:\n{expected}"
             )
         return object_equal
 

--- a/src/coola/equality/handlers/polars_.py
+++ b/src/coola/equality/handlers/polars_.py
@@ -65,15 +65,15 @@ class PolarsDataFrameEqualHandler(BaseEqualityHandler):
 
     def handle(
         self,
-        object1: polars.DataFrame,
-        object2: polars.DataFrame,
+        actual: polars.DataFrame,
+        expected: polars.DataFrame,
         config: EqualityConfig,
     ) -> bool:
-        object_equal = frame_equal(object1, object2, config)
+        object_equal = frame_equal(actual, expected, config)
         if config.show_difference and not object_equal:
             logger.info(
                 f"polars.DataFrames have different elements:\n"
-                f"object1:\n{object1}\nobject2:\n{object2}"
+                f"object1:\n{actual}\nobject2:\n{expected}"
             )
         return object_equal
 
@@ -114,15 +114,15 @@ class PolarsSeriesEqualHandler(BaseEqualityHandler):
 
     def handle(
         self,
-        object1: polars.Series,
-        object2: polars.Series,
+        actual: polars.Series,
+        expected: polars.Series,
         config: EqualityConfig,
     ) -> bool:
-        object_equal = series_equal(object1, object2, config)
+        object_equal = series_equal(actual, expected, config)
         if config.show_difference and not object_equal:
             logger.info(
                 f"polars.Series have different elements:\n"
-                f"object1:\n{object1}\nobject2:\n{object2}"
+                f"object1:\n{actual}\nobject2:\n{expected}"
             )
         return object_equal
 

--- a/src/coola/equality/handlers/scalar.py
+++ b/src/coola/equality/handlers/scalar.py
@@ -51,7 +51,7 @@ class NanEqualHandler(AbstractEqualityHandler):
     ) -> bool:
         if config.equal_nan and math.isnan(actual) and math.isnan(expected):
             return True
-        return self._handle_next(object1=actual, object2=expected, config=config)
+        return self._handle_next(actual=actual, expected=expected, config=config)
 
 
 class ScalarEqualHandler(BaseEqualityHandler):
@@ -90,7 +90,7 @@ class ScalarEqualHandler(BaseEqualityHandler):
     def handle(self, actual: float, expected: float, config: EqualityConfig) -> bool:
         object_equal = number_equal(actual, expected, config)
         if not object_equal and config.show_difference:
-            logger.info(f"numbers are not equal:\nobject1:\n{actual}\nobject2:\n{expected}")
+            logger.info(f"numbers are not equal:\nactual:\n{actual}\nexpected:\n{expected}")
         return object_equal
 
     def set_next_handler(self, handler: BaseEqualityHandler) -> None:

--- a/src/coola/equality/handlers/scalar.py
+++ b/src/coola/equality/handlers/scalar.py
@@ -45,13 +45,13 @@ class NanEqualHandler(AbstractEqualityHandler):
 
     def handle(
         self,
-        object1: float,
-        object2: float,
+        actual: float,
+        expected: float,
         config: EqualityConfig,
     ) -> bool:
-        if config.equal_nan and math.isnan(object1) and math.isnan(object2):
+        if config.equal_nan and math.isnan(actual) and math.isnan(expected):
             return True
-        return self._handle_next(object1=object1, object2=object2, config=config)
+        return self._handle_next(object1=actual, object2=expected, config=config)
 
 
 class ScalarEqualHandler(BaseEqualityHandler):
@@ -87,10 +87,10 @@ class ScalarEqualHandler(BaseEqualityHandler):
     def __repr__(self) -> str:
         return f"{self.__class__.__qualname__}()"
 
-    def handle(self, object1: float, object2: float, config: EqualityConfig) -> bool:
-        object_equal = number_equal(object1, object2, config)
+    def handle(self, actual: float, expected: float, config: EqualityConfig) -> bool:
+        object_equal = number_equal(actual, expected, config)
         if not object_equal and config.show_difference:
-            logger.info(f"numbers are not equal:\nobject1:\n{object1}\nobject2:\n{object2}")
+            logger.info(f"numbers are not equal:\nobject1:\n{actual}\nobject2:\n{expected}")
         return object_equal
 
     def set_next_handler(self, handler: BaseEqualityHandler) -> None:

--- a/src/coola/equality/handlers/sequence.py
+++ b/src/coola/equality/handlers/sequence.py
@@ -52,16 +52,16 @@ class SequenceSameValuesHandler(AbstractEqualityHandler):
     ) -> bool:
         for value1, value2 in zip(actual, expected):
             if not config.tester.equal(value1, value2, config):
-                self._show_difference(object1=actual, object2=expected, config=config)
+                self._show_difference(actual=actual, expected=expected, config=config)
                 return False
-        return self._handle_next(object1=actual, object2=expected, config=config)
+        return self._handle_next(actual=actual, expected=expected, config=config)
 
     def _show_difference(
-        self, object1: Sequence, object2: Sequence, config: EqualityConfig
+        self, actual: Sequence, expected: Sequence, config: EqualityConfig
     ) -> None:
         if config.show_difference:
             logger.info(
                 f"sequences have at least one different value:\n"
-                f"first sequence : {object1}\n"
-                f"second sequence: {object2}"
+                f"first sequence : {actual}\n"
+                f"second sequence: {expected}"
             )

--- a/src/coola/equality/handlers/sequence.py
+++ b/src/coola/equality/handlers/sequence.py
@@ -46,15 +46,15 @@ class SequenceSameValuesHandler(AbstractEqualityHandler):
 
     def handle(
         self,
-        object1: Sequence,
-        object2: Sequence,
+        actual: Sequence,
+        expected: Sequence,
         config: EqualityConfig,
     ) -> bool:
-        for value1, value2 in zip(object1, object2):
+        for value1, value2 in zip(actual, expected):
             if not config.tester.equal(value1, value2, config):
-                self._show_difference(object1=object1, object2=object2, config=config)
+                self._show_difference(object1=actual, object2=expected, config=config)
                 return False
-        return self._handle_next(object1=object1, object2=object2, config=config)
+        return self._handle_next(object1=actual, object2=expected, config=config)
 
     def _show_difference(
         self, object1: Sequence, object2: Sequence, config: EqualityConfig

--- a/src/coola/equality/handlers/shape.py
+++ b/src/coola/equality/handlers/shape.py
@@ -67,4 +67,4 @@ class SameShapeHandler(AbstractEqualityHandler):
             if config.show_difference:
                 logger.info(f"objects have different shapes: {actual.shape} vs {expected.shape}")
             return False
-        return self._handle_next(object1=actual, object2=expected, config=config)
+        return self._handle_next(actual=actual, expected=expected, config=config)

--- a/src/coola/equality/handlers/shape.py
+++ b/src/coola/equality/handlers/shape.py
@@ -61,10 +61,10 @@ class SameShapeHandler(AbstractEqualityHandler):
         return isinstance(other, self.__class__)
 
     def handle(
-        self, object1: SupportsShape, object2: SupportsShape, config: EqualityConfig
+        self, actual: SupportsShape, expected: SupportsShape, config: EqualityConfig
     ) -> bool:
-        if object1.shape != object2.shape:
+        if actual.shape != expected.shape:
             if config.show_difference:
-                logger.info(f"objects have different shapes: {object1.shape} vs {object2.shape}")
+                logger.info(f"objects have different shapes: {actual.shape} vs {expected.shape}")
             return False
-        return self._handle_next(object1=object1, object2=object2, config=config)
+        return self._handle_next(object1=actual, object2=expected, config=config)

--- a/src/coola/equality/handlers/torch_.py
+++ b/src/coola/equality/handlers/torch_.py
@@ -63,7 +63,7 @@ class TorchTensorEqualHandler(BaseEqualityHandler):
         if config.show_difference and not object_equal:
             logger.info(
                 f"torch.Tensors have different elements:\n"
-                f"object1=\n{actual}\nobject2=\n{expected}"
+                f"actual=\n{actual}\nexpected=\n{expected}"
             )
         return object_equal
 
@@ -108,7 +108,7 @@ class TorchTensorSameDeviceHandler(AbstractEqualityHandler):
                     f"torch.Tensors have different devices: {actual.device} vs {expected.device}"
                 )
             return False
-        return self._handle_next(object1=actual, object2=expected, config=config)
+        return self._handle_next(actual=actual, expected=expected, config=config)
 
 
 def tensor_equal(tensor1: torch.Tensor, tensor2: torch.Tensor, config: EqualityConfig) -> bool:

--- a/src/coola/equality/handlers/torch_.py
+++ b/src/coola/equality/handlers/torch_.py
@@ -55,15 +55,15 @@ class TorchTensorEqualHandler(BaseEqualityHandler):
 
     def handle(
         self,
-        object1: torch.Tensor,
-        object2: torch.Tensor,
+        actual: torch.Tensor,
+        expected: torch.Tensor,
         config: EqualityConfig,
     ) -> bool:
-        object_equal = tensor_equal(object1, object2, config)
+        object_equal = tensor_equal(actual, expected, config)
         if config.show_difference and not object_equal:
             logger.info(
                 f"torch.Tensors have different elements:\n"
-                f"object1=\n{object1}\nobject2=\n{object2}"
+                f"object1=\n{actual}\nobject2=\n{expected}"
             )
         return object_equal
 
@@ -98,17 +98,17 @@ class TorchTensorSameDeviceHandler(AbstractEqualityHandler):
 
     def handle(
         self,
-        object1: torch.Tensor,
-        object2: torch.Tensor,
+        actual: torch.Tensor,
+        expected: torch.Tensor,
         config: EqualityConfig,
     ) -> bool | None:
-        if object1.device != object2.device:
+        if actual.device != expected.device:
             if config.show_difference:
                 logger.info(
-                    f"torch.Tensors have different devices: {object1.device} vs {object2.device}"
+                    f"torch.Tensors have different devices: {actual.device} vs {expected.device}"
                 )
             return False
-        return self._handle_next(object1=object1, object2=object2, config=config)
+        return self._handle_next(object1=actual, object2=expected, config=config)
 
 
 def tensor_equal(tensor1: torch.Tensor, tensor2: torch.Tensor, config: EqualityConfig) -> bool:

--- a/src/coola/equality/testers/base.py
+++ b/src/coola/equality/testers/base.py
@@ -18,12 +18,12 @@ class BaseEqualityTester(ABC):
     r"""Define the base class to implement an equality tester."""
 
     @abstractmethod
-    def equal(self, object1: Any, object2: Any, config: EqualityConfig) -> bool:
+    def equal(self, actual: Any, expected: Any, config: EqualityConfig) -> bool:
         r"""Indicate if two objects are equal or not.
 
         Args:
-            object1: Specifies the first object to compare.
-            object2: Specifies the second object to compare.
+            actual: Specifies the first object to compare.
+            expected: Specifies the second object to compare.
             config: Specifies the equality configuration.
 
         Returns:

--- a/src/coola/equality/testers/base.py
+++ b/src/coola/equality/testers/base.py
@@ -22,8 +22,8 @@ class BaseEqualityTester(ABC):
         r"""Indicate if two objects are equal or not.
 
         Args:
-            actual: Specifies the first object to compare.
-            expected: Specifies the second object to compare.
+            actual: Specifies the actual input.
+            expected: Specifies the expected input.
             config: Specifies the equality configuration.
 
         Returns:

--- a/src/coola/equality/testers/default.py
+++ b/src/coola/equality/testers/default.py
@@ -61,8 +61,8 @@ class EqualityTester(BaseEqualityTester):
             raise RuntimeError(msg)
         cls.registry[data_type] = comparator
 
-    def equal(self, object1: Any, object2: Any, config: EqualityConfig) -> bool:
-        return self.find_comparator(type(object1)).equal(object1, object2, config)
+    def equal(self, actual: Any, expected: Any, config: EqualityConfig) -> bool:
+        return self.find_comparator(type(actual)).equal(actual, expected, config)
 
     @classmethod
     def has_comparator(cls, data_type: type) -> bool:
@@ -211,8 +211,8 @@ class LocalEqualityTester(BaseEqualityTester):
         """
         return self.__class__({key: value.clone() for key, value in self.registry.items()})
 
-    def equal(self, object1: Any, object2: Any, config: EqualityConfig) -> bool:
-        return self.find_comparator(type(object1)).equal(object1, object2, config)
+    def equal(self, actual: Any, expected: Any, config: EqualityConfig) -> bool:
+        return self.find_comparator(type(actual)).equal(actual, expected, config)
 
     def has_comparator(self, data_type: type) -> bool:
         r"""Indicate if an equality comparator is registered for the

--- a/tests/unit/equality/checks/test_collection.py
+++ b/tests/unit/equality/checks/test_collection.py
@@ -29,7 +29,7 @@ def test_objects_are_equal_true(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert function(example.object1, example.object2, show_difference=show_difference)
+        assert function(example.actual, example.expected, show_difference=show_difference)
         assert not caplog.messages
 
 
@@ -39,7 +39,7 @@ def test_objects_are_equal_false(
     function: Callable, example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert not function(example.object1, example.object2)
+        assert not function(example.actual, example.expected)
         assert not caplog.messages
 
 
@@ -49,7 +49,7 @@ def test_objects_are_equal_false_show_difference(
     function: Callable, example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert not function(example.object1, example.object2, show_difference=True)
+        assert not function(example.actual, example.expected, show_difference=True)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -58,5 +58,5 @@ def test_objects_are_allclose_true_tolerance(
     example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     assert objects_are_allclose(
-        example.object1, example.object2, atol=example.atol, rtol=example.rtol
+        example.actual, example.expected, atol=example.atol, rtol=example.rtol
     )

--- a/tests/unit/equality/checks/test_default.py
+++ b/tests/unit/equality/checks/test_default.py
@@ -29,7 +29,7 @@ def test_objects_are_equal_true(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert function(example.object1, example.object2, show_difference=show_difference)
+        assert function(example.actual, example.expected, show_difference=show_difference)
         assert not caplog.messages
 
 
@@ -39,7 +39,7 @@ def test_objects_are_equal_false(
     function: Callable, example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert not function(example.object1, example.object2)
+        assert not function(example.actual, example.expected)
         assert not caplog.messages
 
 
@@ -49,5 +49,5 @@ def test_objects_are_equal_false_show_difference(
     function: Callable, example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert not function(example.object1, example.object2, show_difference=True)
+        assert not function(example.actual, example.expected, show_difference=True)
         assert caplog.messages[-1].startswith(example.expected_message)

--- a/tests/unit/equality/checks/test_jax.py
+++ b/tests/unit/equality/checks/test_jax.py
@@ -31,7 +31,7 @@ def test_objects_are_equal_true(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert function(example.object1, example.object2, show_difference=show_difference)
+        assert function(example.actual, example.expected, show_difference=show_difference)
         assert not caplog.messages
 
 
@@ -42,7 +42,7 @@ def test_objects_are_equal_false(
     function: Callable, example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert not function(example.object1, example.object2)
+        assert not function(example.actual, example.expected)
         assert not caplog.messages
 
 
@@ -53,7 +53,7 @@ def test_objects_are_equal_false_show_difference(
     function: Callable, example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert not function(example.object1, example.object2, show_difference=True)
+        assert not function(example.actual, example.expected, show_difference=True)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -63,5 +63,5 @@ def test_objects_are_allclose_true_tolerance(
     example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     assert objects_are_allclose(
-        example.object1, example.object2, atol=example.atol, rtol=example.rtol
+        example.actual, example.expected, atol=example.atol, rtol=example.rtol
     )

--- a/tests/unit/equality/checks/test_numpy.py
+++ b/tests/unit/equality/checks/test_numpy.py
@@ -31,7 +31,7 @@ def test_objects_are_equal_true(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert function(example.object1, example.object2, show_difference=show_difference)
+        assert function(example.actual, example.expected, show_difference=show_difference)
         assert not caplog.messages
 
 
@@ -42,7 +42,7 @@ def test_objects_are_equal_false(
     function: Callable, example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert not function(example.object1, example.object2)
+        assert not function(example.actual, example.expected)
         assert not caplog.messages
 
 
@@ -53,7 +53,7 @@ def test_objects_are_equal_false_show_difference(
     function: Callable, example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert not function(example.object1, example.object2, show_difference=True)
+        assert not function(example.actual, example.expected, show_difference=True)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -63,5 +63,5 @@ def test_objects_are_allclose_true_tolerance(
     example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     assert objects_are_allclose(
-        example.object1, example.object2, atol=example.atol, rtol=example.rtol
+        example.actual, example.expected, atol=example.atol, rtol=example.rtol
     )

--- a/tests/unit/equality/checks/test_pandas.py
+++ b/tests/unit/equality/checks/test_pandas.py
@@ -31,7 +31,7 @@ def test_objects_are_equal_true(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert function(example.object1, example.object2, show_difference=show_difference)
+        assert function(example.actual, example.expected, show_difference=show_difference)
         assert not caplog.messages
 
 
@@ -42,7 +42,7 @@ def test_objects_are_equal_false(
     function: Callable, example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert not function(example.object1, example.object2)
+        assert not function(example.actual, example.expected)
         assert not caplog.messages
 
 
@@ -53,7 +53,7 @@ def test_objects_are_equal_false_show_difference(
     function: Callable, example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert not function(example.object1, example.object2, show_difference=True)
+        assert not function(example.actual, example.expected, show_difference=True)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -63,5 +63,5 @@ def test_objects_are_allclose_true_tolerance(
     example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     assert objects_are_allclose(
-        example.object1, example.object2, atol=example.atol, rtol=example.rtol
+        example.actual, example.expected, atol=example.atol, rtol=example.rtol
     )

--- a/tests/unit/equality/checks/test_polars.py
+++ b/tests/unit/equality/checks/test_polars.py
@@ -31,7 +31,7 @@ def test_objects_are_equal_true(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert function(example.object1, example.object2, show_difference=show_difference)
+        assert function(example.actual, example.expected, show_difference=show_difference)
         assert not caplog.messages
 
 
@@ -42,7 +42,7 @@ def test_objects_are_equal_false(
     function: Callable, example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert not function(example.object1, example.object2)
+        assert not function(example.actual, example.expected)
         assert not caplog.messages
 
 
@@ -53,7 +53,7 @@ def test_objects_are_equal_false_show_difference(
     function: Callable, example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert not function(example.object1, example.object2, show_difference=True)
+        assert not function(example.actual, example.expected, show_difference=True)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -63,5 +63,5 @@ def test_objects_are_allclose_true_tolerance(
     example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     assert objects_are_allclose(
-        example.object1, example.object2, atol=example.atol, rtol=example.rtol
+        example.actual, example.expected, atol=example.atol, rtol=example.rtol
     )

--- a/tests/unit/equality/checks/test_scalar.py
+++ b/tests/unit/equality/checks/test_scalar.py
@@ -29,7 +29,7 @@ def test_objects_are_equal_true(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert function(example.object1, example.object2, show_difference=show_difference)
+        assert function(example.actual, example.expected, show_difference=show_difference)
         assert not caplog.messages
 
 
@@ -39,7 +39,7 @@ def test_objects_are_equal_false(
     function: Callable, example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert not function(example.object1, example.object2)
+        assert not function(example.actual, example.expected)
         assert not caplog.messages
 
 
@@ -49,7 +49,7 @@ def test_objects_are_equal_false_show_difference(
     function: Callable, example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert not function(example.object1, example.object2, show_difference=True)
+        assert not function(example.actual, example.expected, show_difference=True)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -58,5 +58,5 @@ def test_objects_are_allclose_true_tolerance(
     example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     assert objects_are_allclose(
-        example.object1, example.object2, atol=example.atol, rtol=example.rtol
+        example.actual, example.expected, atol=example.atol, rtol=example.rtol
     )

--- a/tests/unit/equality/checks/test_torch.py
+++ b/tests/unit/equality/checks/test_torch.py
@@ -31,7 +31,7 @@ def test_objects_are_equal_true(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert function(example.object1, example.object2, show_difference=show_difference)
+        assert function(example.actual, example.expected, show_difference=show_difference)
         assert not caplog.messages
 
 
@@ -42,7 +42,7 @@ def test_objects_are_equal_false(
     function: Callable, example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert not function(example.object1, example.object2)
+        assert not function(example.actual, example.expected)
         assert not caplog.messages
 
 
@@ -53,7 +53,7 @@ def test_objects_are_equal_false_show_difference(
     function: Callable, example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert not function(example.object1, example.object2, show_difference=True)
+        assert not function(example.actual, example.expected, show_difference=True)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -63,5 +63,5 @@ def test_objects_are_allclose_true_tolerance(
     example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     assert objects_are_allclose(
-        example.object1, example.object2, atol=example.atol, rtol=example.rtol
+        example.actual, example.expected, atol=example.atol, rtol=example.rtol
     )

--- a/tests/unit/equality/checks/test_xarray.py
+++ b/tests/unit/equality/checks/test_xarray.py
@@ -31,7 +31,7 @@ def test_objects_are_equal_true(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert function(example.object1, example.object2, show_difference=show_difference)
+        assert function(example.actual, example.expected, show_difference=show_difference)
         assert not caplog.messages
 
 
@@ -42,7 +42,7 @@ def test_objects_are_equal_false(
     function: Callable, example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert not function(example.object1, example.object2)
+        assert not function(example.actual, example.expected)
         assert not caplog.messages
 
 
@@ -53,7 +53,7 @@ def test_objects_are_equal_false_show_difference(
     function: Callable, example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.INFO):
-        assert not function(example.object1, example.object2, show_difference=True)
+        assert not function(example.actual, example.expected, show_difference=True)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -63,5 +63,5 @@ def test_objects_are_allclose_true_tolerance(
     example: ExamplePair, caplog: pytest.LogCaptureFixture
 ) -> None:
     assert objects_are_allclose(
-        example.object1, example.object2, atol=example.atol, rtol=example.rtol
+        example.actual, example.expected, atol=example.atol, rtol=example.rtol
     )

--- a/tests/unit/equality/comparators/test_collection.py
+++ b/tests/unit/equality/comparators/test_collection.py
@@ -30,14 +30,14 @@ def config() -> EqualityConfig:
 
 
 MAPPING_EQUAL = [
-    pytest.param(ExamplePair(object1={}, object2={}), id="empty dict"),
-    pytest.param(ExamplePair(object1={"a": 1, "b": 2}, object2={"a": 1, "b": 2}), id="flat dict"),
+    pytest.param(ExamplePair(actual={}, expected={}), id="empty dict"),
+    pytest.param(ExamplePair(actual={"a": 1, "b": 2}, expected={"a": 1, "b": 2}), id="flat dict"),
     pytest.param(
-        ExamplePair(object1={"a": 1, "b": {"k": 1}}, object2={"a": 1, "b": {"k": 1}}),
+        ExamplePair(actual={"a": 1, "b": {"k": 1}}, expected={"a": 1, "b": {"k": 1}}),
         id="nested dict",
     ),
     pytest.param(
-        ExamplePair(object1=OrderedDict({"a": 1, "b": 2}), object2=OrderedDict({"a": 1, "b": 2})),
+        ExamplePair(actual=OrderedDict({"a": 1, "b": 2}), expected=OrderedDict({"a": 1, "b": 2})),
         id="OrderedDict",
     ),
 ]
@@ -45,47 +45,47 @@ MAPPING_EQUAL = [
 MAPPING_NOT_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1={"a": 1, "b": 2},
-            object2={"a": 1, "c": 2},
+            actual={"a": 1, "b": 2},
+            expected={"a": 1, "c": 2},
             expected_message="mappings have different keys:",
         ),
         id="different keys",
     ),
     pytest.param(
         ExamplePair(
-            object1={"a": 1, "b": 2},
-            object2={"a": 1, "b": 3},
+            actual={"a": 1, "b": 2},
+            expected={"a": 1, "b": 3},
             expected_message="mappings have at least one different value:",
         ),
         id="different values",
     ),
     pytest.param(
         ExamplePair(
-            object1={"a": 1, "b": {"k": 1}},
-            object2={"a": 1, "b": {"k": 2}},
+            actual={"a": 1, "b": {"k": 1}},
+            expected={"a": 1, "b": {"k": 2}},
             expected_message="mappings have at least one different value:",
         ),
         id="different values - nested",
     ),
     pytest.param(
         ExamplePair(
-            object1={"a": 1, "b": 2},
-            object2={"a": 1, "b": float("nan")},
+            actual={"a": 1, "b": 2},
+            expected={"a": 1, "b": float("nan")},
             expected_message="mappings have at least one different value:",
         ),
         id="different values - nan",
     ),
     pytest.param(
         ExamplePair(
-            object1={"a": 1, "b": 2},
-            object2={"a": 1, "b": 2, "c": 3},
+            actual={"a": 1, "b": 2},
+            expected={"a": 1, "b": 2, "c": 3},
             expected_message="objects have different lengths:",
         ),
         id="different number of items",
     ),
     pytest.param(
         ExamplePair(
-            object1={}, object2=OrderedDict({}), expected_message="objects have different types:"
+            actual={}, expected=OrderedDict({}), expected_message="objects have different types:"
         ),
         id="different types",
     ),
@@ -94,94 +94,94 @@ MAPPING_NOT_EQUAL = [
 MAPPING_EQUAL_TOLERANCE = [
     # atol
     pytest.param(
-        ExamplePair(object1={"a": 1, "b": 2}, object2={"a": 1, "b": 3}, atol=1.0),
+        ExamplePair(actual={"a": 1, "b": 2}, expected={"a": 1, "b": 3}, atol=1.0),
         id="flat dict atol=1",
     ),
     pytest.param(
-        ExamplePair(object1={"a": 1, "b": {"k": 2}}, object2={"a": 1, "b": {"k": 3}}, atol=1.0),
+        ExamplePair(actual={"a": 1, "b": {"k": 2}}, expected={"a": 1, "b": {"k": 3}}, atol=1.0),
         id="nested dict atol=1",
     ),
     pytest.param(
-        ExamplePair(object1={"a": 1, "b": 2}, object2={"a": 4, "b": -2}, atol=10.0),
+        ExamplePair(actual={"a": 1, "b": 2}, expected={"a": 4, "b": -2}, atol=10.0),
         id="flat dict atol=10",
     ),
     pytest.param(
-        ExamplePair(object1={"a": 1.0, "b": 2.0}, object2={"a": 1.0001, "b": 1.9999}, atol=1e-3),
+        ExamplePair(actual={"a": 1.0, "b": 2.0}, expected={"a": 1.0001, "b": 1.9999}, atol=1e-3),
         id="flat dict atol=1e-3",
     ),
     # rtol
     pytest.param(
-        ExamplePair(object1={"a": 1, "b": 2}, object2={"a": 1, "b": 3}, rtol=1.0),
+        ExamplePair(actual={"a": 1, "b": 2}, expected={"a": 1, "b": 3}, rtol=1.0),
         id="flat dict rtol=1",
     ),
     pytest.param(
-        ExamplePair(object1={"a": 1, "b": {"k": 2}}, object2={"a": 1, "b": {"k": 3}}, rtol=1.0),
+        ExamplePair(actual={"a": 1, "b": {"k": 2}}, expected={"a": 1, "b": {"k": 3}}, rtol=1.0),
         id="nested dict rtol=1",
     ),
     pytest.param(
-        ExamplePair(object1={"a": 1, "b": 2}, object2={"a": 4, "b": -2}, rtol=10.0),
+        ExamplePair(actual={"a": 1, "b": 2}, expected={"a": 4, "b": -2}, rtol=10.0),
         id="flat dict rtol=10",
     ),
     pytest.param(
-        ExamplePair(object1={"a": 1.0, "b": 2.0}, object2={"a": 1.0001, "b": 1.9999}, rtol=1e-3),
+        ExamplePair(actual={"a": 1.0, "b": 2.0}, expected={"a": 1.0001, "b": 1.9999}, rtol=1e-3),
         id="flat dict rtol=1e-3",
     ),
 ]
 
 SEQUENCE_EQUAL = [
-    pytest.param(ExamplePair(object1=[], object2=[]), id="empty list"),
-    pytest.param(ExamplePair(object1=(), object2=()), id="empty tuple"),
-    pytest.param(ExamplePair(object1=deque(), object2=deque()), id="empty deque"),
-    pytest.param(ExamplePair(object1=[1, 2, 3, "abc"], object2=[1, 2, 3, "abc"]), id="flat list"),
+    pytest.param(ExamplePair(actual=[], expected=[]), id="empty list"),
+    pytest.param(ExamplePair(actual=(), expected=()), id="empty tuple"),
+    pytest.param(ExamplePair(actual=deque(), expected=deque()), id="empty deque"),
+    pytest.param(ExamplePair(actual=[1, 2, 3, "abc"], expected=[1, 2, 3, "abc"]), id="flat list"),
     pytest.param(
-        ExamplePair(object1=[1, 2, [3, 4, 5]], object2=[1, 2, [3, 4, 5]]),
+        ExamplePair(actual=[1, 2, [3, 4, 5]], expected=[1, 2, [3, 4, 5]]),
         id="nested list",
     ),
     pytest.param(
         ExamplePair(
-            object1=(1, 2, 3),
-            object2=(1, 2, 3),
+            actual=(1, 2, 3),
+            expected=(1, 2, 3),
         ),
         id="flat tuple",
     ),
-    pytest.param(ExamplePair(object1=deque([1, 2, 3]), object2=deque([1, 2, 3])), id="deque"),
+    pytest.param(ExamplePair(actual=deque([1, 2, 3]), expected=deque([1, 2, 3])), id="deque"),
 ]
 
 SEQUENCE_NOT_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=[1, 2, 3],
-            object2=[1, 2, 4],
+            actual=[1, 2, 3],
+            expected=[1, 2, 4],
             expected_message="sequences have at least one different value:",
         ),
         id="different values",
     ),
     pytest.param(
         ExamplePair(
-            object1=[1, 2, [3, 4, 5]],
-            object2=[1, 2, [3, 4, 6]],
+            actual=[1, 2, [3, 4, 5]],
+            expected=[1, 2, [3, 4, 6]],
             expected_message="sequences have at least one different value:",
         ),
         id="different values - nested",
     ),
     pytest.param(
         ExamplePair(
-            object1=[1, 2, 3],
-            object2=[1, 2, float("nan")],
+            actual=[1, 2, 3],
+            expected=[1, 2, float("nan")],
             expected_message="sequences have at least one different value:",
         ),
         id="different values - nan",
     ),
     pytest.param(
         ExamplePair(
-            object1=[1, 2, 3],
-            object2=[1, 2],
+            actual=[1, 2, 3],
+            expected=[1, 2],
             expected_message="objects have different lengths:",
         ),
         id="different lengths",
     ),
     pytest.param(
-        ExamplePair(object1=[], object2=(), expected_message="objects have different types:"),
+        ExamplePair(actual=[], expected=(), expected_message="objects have different types:"),
         id="different types",
     ),
 ]
@@ -189,32 +189,32 @@ SEQUENCE_NOT_EQUAL = [
 SEQUENCE_EQUAL_TOLERANCE = [
     # atol
     pytest.param(
-        ExamplePair(object1=[1, 2, 3], object2=[1, 2, 4], atol=1.0), id="flat sequence atol=1"
+        ExamplePair(actual=[1, 2, 3], expected=[1, 2, 4], atol=1.0), id="flat sequence atol=1"
     ),
     pytest.param(
-        ExamplePair(object1=[1, 2, [3, 4, 5]], object2=[1, 2, [4, 5, 6]], atol=1.0),
+        ExamplePair(actual=[1, 2, [3, 4, 5]], expected=[1, 2, [4, 5, 6]], atol=1.0),
         id="nested sequence atol=1",
     ),
     pytest.param(
-        ExamplePair(object1=[1, 2, 3], object2=[-4, 5, 6], atol=10.0), id="flat sequence atol=10"
+        ExamplePair(actual=[1, 2, 3], expected=[-4, 5, 6], atol=10.0), id="flat sequence atol=10"
     ),
     pytest.param(
-        ExamplePair(object1=[1.0, 2.0, 3.0], object2=[1.0001, 1.9999, 3.0001], atol=1e-3),
+        ExamplePair(actual=[1.0, 2.0, 3.0], expected=[1.0001, 1.9999, 3.0001], atol=1e-3),
         id="flat sequence atol=1e-3",
     ),
     # rtol
     pytest.param(
-        ExamplePair(object1=[1, 2, 3], object2=[1, 2, 4], rtol=1.0), id="flat sequence rtol=1"
+        ExamplePair(actual=[1, 2, 3], expected=[1, 2, 4], rtol=1.0), id="flat sequence rtol=1"
     ),
     pytest.param(
-        ExamplePair(object1=[1, 2, [3, 4, 5]], object2=[1, 2, [4, 5, 6]], rtol=1.0),
+        ExamplePair(actual=[1, 2, [3, 4, 5]], expected=[1, 2, [4, 5, 6]], rtol=1.0),
         id="nested sequence rtol=1",
     ),
     pytest.param(
-        ExamplePair(object1=[1, 2, 3], object2=[-4, 5, 6], rtol=10.0), id="flat sequence rtol=10"
+        ExamplePair(actual=[1, 2, 3], expected=[-4, 5, 6], rtol=10.0), id="flat sequence rtol=10"
     ),
     pytest.param(
-        ExamplePair(object1=[1.0, 2.0, 3.0], object2=[1.0001, 1.9999, 3.0001], rtol=1e-3),
+        ExamplePair(actual=[1.0, 2.0, 3.0], expected=[1.0001, 1.9999, 3.0001], rtol=1e-3),
         id="flat sequence rtol=1e-3",
     ),
 ]
@@ -263,7 +263,7 @@ def test_mapping_equality_comparator_equal_yes(
 ) -> None:
     comparator = MappingEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -276,7 +276,7 @@ def test_mapping_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = MappingEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -288,7 +288,7 @@ def test_mapping_equality_comparator_equal_false(
 ) -> None:
     comparator = MappingEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -301,7 +301,7 @@ def test_mapping_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = MappingEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -325,13 +325,13 @@ def test_mapping_equality_comparator_equal_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert MappingEqualityComparator().equal(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 
 @numpy_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ({"a": np.ones((2, 3)), "b": np.zeros(2)}, {"a": np.ones((2, 3)), "b": np.zeros(2)}),
         (
@@ -341,14 +341,14 @@ def test_mapping_equality_comparator_equal_true_tolerance(
     ],
 )
 def test_mapping_equality_comparator_equal_true_numpy(
-    object1: Mapping, object2: Mapping, config: EqualityConfig
+    actual: Mapping, expected: Mapping, config: EqualityConfig
 ) -> None:
-    assert MappingEqualityComparator().equal(object1, object2, config)
+    assert MappingEqualityComparator().equal(actual, expected, config)
 
 
 @numpy_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ({"a": np.ones((2, 3)), "b": np.zeros(2)}, {"a": np.ones((2, 3)), "b": np.ones(2)}),
         (
@@ -358,9 +358,9 @@ def test_mapping_equality_comparator_equal_true_numpy(
     ],
 )
 def test_mapping_equality_comparator_equal_false_numpy(
-    object1: Mapping, object2: Mapping, config: EqualityConfig
+    actual: Mapping, expected: Mapping, config: EqualityConfig
 ) -> None:
-    assert not MappingEqualityComparator().equal(object1, object2, config)
+    assert not MappingEqualityComparator().equal(actual, expected, config)
 
 
 ################################################
@@ -395,7 +395,7 @@ def test_sequence_equality_comparator_equal_true_same_object(config: EqualityCon
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ([], []),
         ((), ()),
@@ -408,11 +408,11 @@ def test_sequence_equality_comparator_equal_true_same_object(config: EqualityCon
     ],
 )
 def test_sequence_equality_comparator_equal_true(
-    caplog: pytest.LogCaptureFixture, object1: Sequence, object2: Sequence, config: EqualityConfig
+    caplog: pytest.LogCaptureFixture, actual: Sequence, expected: Sequence, config: EqualityConfig
 ) -> None:
     comparator = SequenceEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1, object2, config)
+        assert comparator.equal(actual, expected, config)
         assert not caplog.messages
 
 
@@ -434,7 +434,7 @@ def test_sequence_equality_comparator_equal_yes(
 ) -> None:
     comparator = SequenceEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -447,7 +447,7 @@ def test_sequence_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = SequenceEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -459,7 +459,7 @@ def test_sequence_equality_comparator_equal_false(
 ) -> None:
     comparator = SequenceEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -472,7 +472,7 @@ def test_sequence_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = SequenceEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -496,13 +496,13 @@ def test_sequence_equality_comparator_equal_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert SequenceEqualityComparator().equal(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 
 @numpy_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ([np.ones((2, 3)), np.zeros(2)], [np.ones((2, 3)), np.zeros(2)]),
         ((np.ones((2, 3)), np.zeros(2)), (np.ones((2, 3)), np.zeros(2))),
@@ -510,23 +510,23 @@ def test_sequence_equality_comparator_equal_true_tolerance(
     ],
 )
 def test_sequence_equality_comparator_equal_true_numpy(
-    object1: Sequence, object2: Sequence, config: EqualityConfig
+    actual: Sequence, expected: Sequence, config: EqualityConfig
 ) -> None:
-    assert SequenceEqualityComparator().equal(object1, object2, config)
+    assert SequenceEqualityComparator().equal(actual, expected, config)
 
 
 @numpy_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ([np.ones((2, 3)), np.zeros(2)], [np.ones((2, 3)), np.ones(2)]),
         ((np.ones((2, 3)), np.zeros(2)), (np.ones((2, 3)), np.ones(2))),
     ],
 )
 def test_sequence_equality_comparator_equal_false_numpy(
-    object1: Sequence, object2: Sequence, config: EqualityConfig
+    actual: Sequence, expected: Sequence, config: EqualityConfig
 ) -> None:
-    assert not SequenceEqualityComparator().equal(object1, object2, config)
+    assert not SequenceEqualityComparator().equal(actual, expected, config)
 
 
 #################################################

--- a/tests/unit/equality/comparators/test_collection.py
+++ b/tests/unit/equality/comparators/test_collection.py
@@ -263,7 +263,7 @@ def test_mapping_equality_comparator_equal_yes(
 ) -> None:
     comparator = MappingEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -276,7 +276,7 @@ def test_mapping_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = MappingEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -288,7 +288,7 @@ def test_mapping_equality_comparator_equal_false(
 ) -> None:
     comparator = MappingEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -301,7 +301,7 @@ def test_mapping_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = MappingEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -310,8 +310,8 @@ def test_mapping_equality_comparator_equal_nan(config: EqualityConfig, equal_nan
     config.equal_nan = equal_nan
     assert (
         MappingEqualityComparator().equal(
-            object1={"a": float("nan"), "b": float("nan")},
-            object2={"a": float("nan"), "b": float("nan")},
+            actual={"a": float("nan"), "b": float("nan")},
+            expected={"a": float("nan"), "b": float("nan")},
             config=config,
         )
         == equal_nan
@@ -325,7 +325,7 @@ def test_mapping_equality_comparator_equal_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert MappingEqualityComparator().equal(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 
@@ -422,7 +422,7 @@ def test_sequence_equality_comparator_equal_true_show_difference(
     config.show_difference = True
     comparator = SequenceEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=[1], object2=[1], config=config)
+        assert comparator.equal(actual=[1], expected=[1], config=config)
         assert not caplog.messages
 
 
@@ -434,7 +434,7 @@ def test_sequence_equality_comparator_equal_yes(
 ) -> None:
     comparator = SequenceEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -447,7 +447,7 @@ def test_sequence_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = SequenceEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -459,7 +459,7 @@ def test_sequence_equality_comparator_equal_false(
 ) -> None:
     comparator = SequenceEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -472,7 +472,7 @@ def test_sequence_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = SequenceEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -481,8 +481,8 @@ def test_sequence_equality_comparator_equal_nan(config: EqualityConfig, equal_na
     config.equal_nan = equal_nan
     assert (
         SequenceEqualityComparator().equal(
-            object1=[float("nan"), 2, float("nan")],
-            object2=[float("nan"), 2, float("nan")],
+            actual=[float("nan"), 2, float("nan")],
+            expected=[float("nan"), 2, float("nan")],
             config=config,
         )
         == equal_nan
@@ -496,7 +496,7 @@ def test_sequence_equality_comparator_equal_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert SequenceEqualityComparator().equal(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 

--- a/tests/unit/equality/comparators/test_default.py
+++ b/tests/unit/equality/comparators/test_default.py
@@ -106,7 +106,7 @@ def test_default_equality_comparator_equal_true_show_difference(
     config.show_difference = True
     comparator = DefaultEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=1, object2=1, config=config)
+        assert comparator.equal(actual=1, expected=1, config=config)
         assert not caplog.messages
 
 
@@ -140,7 +140,7 @@ def test_default_equality_comparator_equal_different_value_show_difference(
     config.show_difference = True
     comparator = DefaultEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=1, object2=2, config=config)
+        assert not comparator.equal(actual=1, expected=2, config=config)
         assert caplog.messages[0].startswith("objects are different:")
 
 
@@ -149,7 +149,7 @@ def test_default_equality_comparator_equal_different_type(
 ) -> None:
     comparator = DefaultEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=[], object2=(), config=config)
+        assert not comparator.equal(actual=[], expected=(), config=config)
         assert not caplog.messages
 
 
@@ -159,7 +159,7 @@ def test_default_equality_comparator_equal_different_type_show_difference(
     config.show_difference = True
     comparator = DefaultEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=[], object2=(), config=config)
+        assert not comparator.equal(actual=[], expected=(), config=config)
         assert caplog.messages[0].startswith("objects have different types:")
 
 
@@ -171,7 +171,7 @@ def test_default_equality_comparator_equal_yes(
 ) -> None:
     comparator = DefaultEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -184,7 +184,7 @@ def test_default_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = DefaultEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -196,7 +196,7 @@ def test_default_equality_comparator_equal_false(
 ) -> None:
     comparator = DefaultEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -209,7 +209,7 @@ def test_default_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = DefaultEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 

--- a/tests/unit/equality/comparators/test_default.py
+++ b/tests/unit/equality/comparators/test_default.py
@@ -18,29 +18,29 @@ def config() -> EqualityConfig:
 
 
 DEFAULT_EQUAL = [
-    pytest.param(ExamplePair(object1=4.2, object2=4.2), id="float"),
-    pytest.param(ExamplePair(object1=42, object2=42), id="int"),
-    pytest.param(ExamplePair(object1="abc", object2="abc"), id="str"),
-    pytest.param(ExamplePair(object1=True, object2=True), id="bool"),
-    pytest.param(ExamplePair(object1=None, object2=None), id="none"),
+    pytest.param(ExamplePair(actual=4.2, expected=4.2), id="float"),
+    pytest.param(ExamplePair(actual=42, expected=42), id="int"),
+    pytest.param(ExamplePair(actual="abc", expected="abc"), id="str"),
+    pytest.param(ExamplePair(actual=True, expected=True), id="bool"),
+    pytest.param(ExamplePair(actual=None, expected=None), id="none"),
 ]
 
 
 DEFAULT_NOT_EQUAL = [
     pytest.param(
-        ExamplePair(object1="abc", object2="def", expected_message="objects are different:"),
+        ExamplePair(actual="abc", expected="def", expected_message="objects are different:"),
         id="different values - str",
     ),
     pytest.param(
-        ExamplePair(object1=4.2, object2="meow", expected_message="objects have different types:"),
+        ExamplePair(actual=4.2, expected="meow", expected_message="objects have different types:"),
         id="float vs str",
     ),
     pytest.param(
-        ExamplePair(object1=1.0, object2=1, expected_message="objects have different types:"),
+        ExamplePair(actual=1.0, expected=1, expected_message="objects have different types:"),
         id="float vs int",
     ),
     pytest.param(
-        ExamplePair(object1=1.0, object2=None, expected_message="objects have different types:"),
+        ExamplePair(actual=1.0, expected=None, expected_message="objects have different types:"),
         id="float vs none",
     ),
 ]
@@ -75,7 +75,7 @@ def test_default_equality_comparator_equal_true_same_object(config: EqualityConf
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (1, 1),
         (0, 0),
@@ -90,13 +90,13 @@ def test_default_equality_comparator_equal_true_same_object(config: EqualityConf
 )
 def test_default_equality_comparator_equal_true(
     caplog: pytest.LogCaptureFixture,
-    object1: bool | float | None,
-    object2: bool | float | None,
+    actual: bool | float | None,
+    expected: bool | float | None,
     config: EqualityConfig,
 ) -> None:
     comparator = DefaultEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1, object2, config)
+        assert comparator.equal(actual, expected, config)
         assert not caplog.messages
 
 
@@ -111,7 +111,7 @@ def test_default_equality_comparator_equal_true_show_difference(
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (1, 2),
         (1.0, 2.0),
@@ -124,13 +124,13 @@ def test_default_equality_comparator_equal_true_show_difference(
 )
 def test_default_equality_comparator_equal_false_scalar(
     caplog: pytest.LogCaptureFixture,
-    object1: bool | float,
-    object2: bool | float | None,
+    actual: bool | float,
+    expected: bool | float | None,
     config: EqualityConfig,
 ) -> None:
     comparator = DefaultEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1, object2, config)
+        assert not comparator.equal(actual, expected, config)
         assert not caplog.messages
 
 
@@ -171,7 +171,7 @@ def test_default_equality_comparator_equal_yes(
 ) -> None:
     comparator = DefaultEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -184,7 +184,7 @@ def test_default_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = DefaultEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -196,7 +196,7 @@ def test_default_equality_comparator_equal_false(
 ) -> None:
     comparator = DefaultEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -209,7 +209,7 @@ def test_default_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = DefaultEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 

--- a/tests/unit/equality/comparators/test_jax.py
+++ b/tests/unit/equality/comparators/test_jax.py
@@ -152,7 +152,7 @@ def test_jax_array_equality_comparator_equal_yes(
 ) -> None:
     comparator = JaxArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -166,7 +166,7 @@ def test_jax_array_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = JaxArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -179,7 +179,7 @@ def test_jax_array_equality_comparator_equal_false(
 ) -> None:
     comparator = JaxArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -193,7 +193,7 @@ def test_jax_array_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = JaxArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -203,8 +203,8 @@ def test_jax_array_equality_comparator_equal_nan(config: EqualityConfig, equal_n
     config.equal_nan = equal_nan
     assert (
         JaxArrayEqualityComparator().equal(
-            object1=jnp.array([0.0, jnp.nan, jnp.nan, 1.2]),
-            object2=jnp.array([0.0, jnp.nan, jnp.nan, 1.2]),
+            actual=jnp.array([0.0, jnp.nan, jnp.nan, 1.2]),
+            expected=jnp.array([0.0, jnp.nan, jnp.nan, 1.2]),
             config=config,
         )
         == equal_nan
@@ -219,7 +219,7 @@ def test_jax_array_equality_comparator_equal_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert JaxArrayEqualityComparator().equal(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 

--- a/tests/unit/equality/comparators/test_jax.py
+++ b/tests/unit/equality/comparators/test_jax.py
@@ -30,50 +30,50 @@ def config() -> EqualityConfig:
 JAX_ARRAY_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=jnp.ones(shape=(2, 3), dtype=float), object2=jnp.ones(shape=(2, 3), dtype=float)
+            actual=jnp.ones(shape=(2, 3), dtype=float), expected=jnp.ones(shape=(2, 3), dtype=float)
         ),
         id="float dtype",
     ),
     pytest.param(
         ExamplePair(
-            object1=jnp.ones(shape=(2, 3), dtype=int), object2=jnp.ones(shape=(2, 3), dtype=int)
+            actual=jnp.ones(shape=(2, 3), dtype=int), expected=jnp.ones(shape=(2, 3), dtype=int)
         ),
         id="int dtype",
     ),
-    pytest.param(ExamplePair(object1=jnp.ones(shape=6), object2=jnp.ones(shape=6)), id="1d array"),
+    pytest.param(ExamplePair(actual=jnp.ones(shape=6), expected=jnp.ones(shape=6)), id="1d array"),
     pytest.param(
-        ExamplePair(object1=jnp.ones(shape=(2, 3)), object2=jnp.ones(shape=(2, 3))), id="2d array"
+        ExamplePair(actual=jnp.ones(shape=(2, 3)), expected=jnp.ones(shape=(2, 3))), id="2d array"
     ),
 ]
 JAX_ARRAY_NOT_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=jnp.ones(shape=(2, 3), dtype=float),
-            object2=jnp.ones(shape=(2, 3), dtype=int),
+            actual=jnp.ones(shape=(2, 3), dtype=float),
+            expected=jnp.ones(shape=(2, 3), dtype=int),
             expected_message="objects have different data types:",
         ),
         id="different data types",
     ),
     pytest.param(
         ExamplePair(
-            object1=jnp.ones(shape=(2, 3)),
-            object2=jnp.ones(shape=6),
+            actual=jnp.ones(shape=(2, 3)),
+            expected=jnp.ones(shape=6),
             expected_message="objects have different shapes:",
         ),
         id="different shapes",
     ),
     pytest.param(
         ExamplePair(
-            object1=jnp.ones(shape=(2, 3)),
-            object2=jnp.zeros(shape=(2, 3)),
+            actual=jnp.ones(shape=(2, 3)),
+            expected=jnp.zeros(shape=(2, 3)),
             expected_message="jax.numpy.ndarrays have different elements:",
         ),
         id="different values",
     ),
     pytest.param(
         ExamplePair(
-            object1=jnp.ones(shape=(2, 3)),
-            object2="meow",
+            actual=jnp.ones(shape=(2, 3)),
+            expected="meow",
             expected_message="objects have different types:",
         ),
         id="different types",
@@ -82,28 +82,28 @@ JAX_ARRAY_NOT_EQUAL = [
 JAX_ARRAY_EQUAL_TOLERANCE = [
     # atol
     pytest.param(
-        ExamplePair(object1=jnp.ones((2, 3)), object2=jnp.full((2, 3), 1.5), atol=1.0),
+        ExamplePair(actual=jnp.ones((2, 3)), expected=jnp.full((2, 3), 1.5), atol=1.0),
         id="atol=1",
     ),
     pytest.param(
-        ExamplePair(object1=jnp.ones((2, 3)), object2=jnp.full((2, 3), 1.05), atol=0.1),
+        ExamplePair(actual=jnp.ones((2, 3)), expected=jnp.full((2, 3), 1.05), atol=0.1),
         id="atol=0.1",
     ),
     pytest.param(
-        ExamplePair(object1=jnp.ones((2, 3)), object2=jnp.full((2, 3), 1.005), atol=0.01),
+        ExamplePair(actual=jnp.ones((2, 3)), expected=jnp.full((2, 3), 1.005), atol=0.01),
         id="atol=0.01",
     ),
     # rtol
     pytest.param(
-        ExamplePair(object1=jnp.ones((2, 3)), object2=jnp.full((2, 3), 1.5), rtol=1.0),
+        ExamplePair(actual=jnp.ones((2, 3)), expected=jnp.full((2, 3), 1.5), rtol=1.0),
         id="rtol=1",
     ),
     pytest.param(
-        ExamplePair(object1=jnp.ones((2, 3)), object2=jnp.full((2, 3), 1.05), rtol=0.1),
+        ExamplePair(actual=jnp.ones((2, 3)), expected=jnp.full((2, 3), 1.05), rtol=0.1),
         id="rtol=0.1",
     ),
     pytest.param(
-        ExamplePair(object1=jnp.ones((2, 3)), object2=jnp.full((2, 3), 1.005), rtol=0.01),
+        ExamplePair(actual=jnp.ones((2, 3)), expected=jnp.full((2, 3), 1.005), rtol=0.01),
         id="rtol=0.01",
     ),
 ]
@@ -152,7 +152,7 @@ def test_jax_array_equality_comparator_equal_yes(
 ) -> None:
     comparator = JaxArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -166,7 +166,7 @@ def test_jax_array_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = JaxArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -179,7 +179,7 @@ def test_jax_array_equality_comparator_equal_false(
 ) -> None:
     comparator = JaxArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -193,7 +193,7 @@ def test_jax_array_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = JaxArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -219,7 +219,7 @@ def test_jax_array_equality_comparator_equal_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert JaxArrayEqualityComparator().equal(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 

--- a/tests/unit/equality/comparators/test_numpy.py
+++ b/tests/unit/equality/comparators/test_numpy.py
@@ -30,50 +30,50 @@ def config() -> EqualityConfig:
 NUMPY_ARRAY_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=np.ones(shape=(2, 3), dtype=float), object2=np.ones(shape=(2, 3), dtype=float)
+            actual=np.ones(shape=(2, 3), dtype=float), expected=np.ones(shape=(2, 3), dtype=float)
         ),
         id="float dtype",
     ),
     pytest.param(
         ExamplePair(
-            object1=np.ones(shape=(2, 3), dtype=int), object2=np.ones(shape=(2, 3), dtype=int)
+            actual=np.ones(shape=(2, 3), dtype=int), expected=np.ones(shape=(2, 3), dtype=int)
         ),
         id="int dtype",
     ),
-    pytest.param(ExamplePair(object1=np.ones(shape=6), object2=np.ones(shape=6)), id="1d array"),
+    pytest.param(ExamplePair(actual=np.ones(shape=6), expected=np.ones(shape=6)), id="1d array"),
     pytest.param(
-        ExamplePair(object1=np.ones(shape=(2, 3)), object2=np.ones(shape=(2, 3))), id="2d array"
+        ExamplePair(actual=np.ones(shape=(2, 3)), expected=np.ones(shape=(2, 3))), id="2d array"
     ),
 ]
 NUMPY_ARRAY_NOT_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=np.ones(shape=(2, 3), dtype=float),
-            object2=np.ones(shape=(2, 3), dtype=int),
+            actual=np.ones(shape=(2, 3), dtype=float),
+            expected=np.ones(shape=(2, 3), dtype=int),
             expected_message="objects have different data types:",
         ),
         id="different data types",
     ),
     pytest.param(
         ExamplePair(
-            object1=np.ones(shape=(2, 3)),
-            object2=np.ones(shape=6),
+            actual=np.ones(shape=(2, 3)),
+            expected=np.ones(shape=6),
             expected_message="objects have different shapes:",
         ),
         id="different shapes",
     ),
     pytest.param(
         ExamplePair(
-            object1=np.ones(shape=(2, 3)),
-            object2=np.zeros(shape=(2, 3)),
+            actual=np.ones(shape=(2, 3)),
+            expected=np.zeros(shape=(2, 3)),
             expected_message="numpy.ndarrays have different elements:",
         ),
         id="different values",
     ),
     pytest.param(
         ExamplePair(
-            object1=np.ones(shape=(2, 3)),
-            object2="meow",
+            actual=np.ones(shape=(2, 3)),
+            expected="meow",
             expected_message="objects have different types:",
         ),
         id="different types",
@@ -82,28 +82,28 @@ NUMPY_ARRAY_NOT_EQUAL = [
 NUMPY_ARRAY_EQUAL_TOLERANCE = [
     # atol
     pytest.param(
-        ExamplePair(object1=np.ones((2, 3)), object2=np.full((2, 3), 1.5), atol=1.0),
+        ExamplePair(actual=np.ones((2, 3)), expected=np.full((2, 3), 1.5), atol=1.0),
         id="atol=1",
     ),
     pytest.param(
-        ExamplePair(object1=np.ones((2, 3)), object2=np.full((2, 3), 1.05), atol=0.1),
+        ExamplePair(actual=np.ones((2, 3)), expected=np.full((2, 3), 1.05), atol=0.1),
         id="atol=0.1",
     ),
     pytest.param(
-        ExamplePair(object1=np.ones((2, 3)), object2=np.full((2, 3), 1.005), atol=0.01),
+        ExamplePair(actual=np.ones((2, 3)), expected=np.full((2, 3), 1.005), atol=0.01),
         id="atol=0.01",
     ),
     # rtol
     pytest.param(
-        ExamplePair(object1=np.ones((2, 3)), object2=np.full((2, 3), 1.5), rtol=1.0),
+        ExamplePair(actual=np.ones((2, 3)), expected=np.full((2, 3), 1.5), rtol=1.0),
         id="rtol=1",
     ),
     pytest.param(
-        ExamplePair(object1=np.ones((2, 3)), object2=np.full((2, 3), 1.05), rtol=0.1),
+        ExamplePair(actual=np.ones((2, 3)), expected=np.full((2, 3), 1.05), rtol=0.1),
         id="rtol=0.1",
     ),
     pytest.param(
-        ExamplePair(object1=np.ones((2, 3)), object2=np.full((2, 3), 1.005), rtol=0.01),
+        ExamplePair(actual=np.ones((2, 3)), expected=np.full((2, 3), 1.005), rtol=0.01),
         id="rtol=0.01",
     ),
 ]
@@ -111,28 +111,28 @@ NUMPY_ARRAY_EQUAL_TOLERANCE = [
 NUMPY_MASKED_ARRAY_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=np.ma.array(data=[0.0, 1.0, 1.2], mask=[0, 1, 0], dtype=float),
-            object2=np.ma.array(data=[0.0, 1.0, 1.2], mask=[0, 1, 0], dtype=float),
+            actual=np.ma.array(data=[0.0, 1.0, 1.2], mask=[0, 1, 0], dtype=float),
+            expected=np.ma.array(data=[0.0, 1.0, 1.2], mask=[0, 1, 0], dtype=float),
         ),
         id="float dtype",
     ),
     pytest.param(
         ExamplePair(
-            object1=np.ma.array(data=[0, 1, 2], mask=[0, 1, 0], dtype=int),
-            object2=np.ma.array(data=[0, 1, 2], mask=[0, 1, 0], dtype=int),
+            actual=np.ma.array(data=[0, 1, 2], mask=[0, 1, 0], dtype=int),
+            expected=np.ma.array(data=[0, 1, 2], mask=[0, 1, 0], dtype=int),
         ),
         id="int dtype",
     ),
     pytest.param(
         ExamplePair(
-            object1=np.ma.array(data=[0.0, 1.0, 1.2]), object2=np.ma.array(data=[0.0, 1.0, 1.2])
+            actual=np.ma.array(data=[0.0, 1.0, 1.2]), expected=np.ma.array(data=[0.0, 1.0, 1.2])
         ),
         id="1d array",
     ),
     pytest.param(
         ExamplePair(
-            object1=np.ma.array(data=np.ones(shape=(2, 3)), mask=[[0, 1, 0], [1, 0, 0]]),
-            object2=np.ma.array(data=np.ones(shape=(2, 3)), mask=[[0, 1, 0], [1, 0, 0]]),
+            actual=np.ma.array(data=np.ones(shape=(2, 3)), mask=[[0, 1, 0], [1, 0, 0]]),
+            expected=np.ma.array(data=np.ones(shape=(2, 3)), mask=[[0, 1, 0], [1, 0, 0]]),
         ),
         id="2d array",
     ),
@@ -140,48 +140,48 @@ NUMPY_MASKED_ARRAY_EQUAL = [
 NUMPY_MASKED_ARRAY_NOT_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=np.ma.array(data=[0.0, 1.0, 1.2], mask=[0, 1, 0], dtype=float),
-            object2=np.ma.array(data=[0.0, 1.0, 1.2], mask=[0, 1, 0], dtype=int),
+            actual=np.ma.array(data=[0.0, 1.0, 1.2], mask=[0, 1, 0], dtype=float),
+            expected=np.ma.array(data=[0.0, 1.0, 1.2], mask=[0, 1, 0], dtype=int),
             expected_message="objects have different data types:",
         ),
         id="different data types",
     ),
     pytest.param(
         ExamplePair(
-            object1=np.ma.array(data=np.ones(shape=(2, 3)), mask=[[0, 1, 0], [1, 0, 0]]),
-            object2=np.ma.array(data=np.ones(shape=(3, 2)), mask=[[0, 1], [1, 0], [0, 0]]),
+            actual=np.ma.array(data=np.ones(shape=(2, 3)), mask=[[0, 1, 0], [1, 0, 0]]),
+            expected=np.ma.array(data=np.ones(shape=(3, 2)), mask=[[0, 1], [1, 0], [0, 0]]),
             expected_message="objects have different shapes:",
         ),
         id="different shapes",
     ),
     pytest.param(
         ExamplePair(
-            object1=np.ma.array(data=[0.0, 1.0, 1.2], mask=[0, 1, 0]),
-            object2=np.ma.array(data=[0.0, 1.0, 2.0], mask=[0, 1, 0]),
+            actual=np.ma.array(data=[0.0, 1.0, 1.2], mask=[0, 1, 0]),
+            expected=np.ma.array(data=[0.0, 1.0, 2.0], mask=[0, 1, 0]),
             expected_message="objects have different data:",
         ),
         id="different values",
     ),
     pytest.param(
         ExamplePair(
-            object1=np.ma.array(data=[0.0, 1.0, 1.2], mask=[0, 1, 0]),
-            object2=np.ma.array(data=[0.0, 1.0, 1.2], mask=[0, 0, 1]),
+            actual=np.ma.array(data=[0.0, 1.0, 1.2], mask=[0, 1, 0]),
+            expected=np.ma.array(data=[0.0, 1.0, 1.2], mask=[0, 0, 1]),
             expected_message="objects have different mask:",
         ),
         id="different mask",
     ),
     pytest.param(
         ExamplePair(
-            object1=np.ma.array(data=[0.0, 1.0, 1.2], mask=[0, 1, 0], fill_value=-1),
-            object2=np.ma.array(data=[0.0, 1.0, 1.2], mask=[0, 1, 0], fill_value=42),
+            actual=np.ma.array(data=[0.0, 1.0, 1.2], mask=[0, 1, 0], fill_value=-1),
+            expected=np.ma.array(data=[0.0, 1.0, 1.2], mask=[0, 1, 0], fill_value=42),
             expected_message="objects have different fill_value:",
         ),
         id="different fill_value",
     ),
     pytest.param(
         ExamplePair(
-            object1=np.ma.array(data=np.ones(shape=(2, 3)), mask=[[0, 1, 0], [1, 0, 0]]),
-            object2=np.ones(shape=(2, 3)),
+            actual=np.ma.array(data=np.ones(shape=(2, 3)), mask=[[0, 1, 0], [1, 0, 0]]),
+            expected=np.ones(shape=(2, 3)),
             expected_message="objects have different types:",
         ),
         id="different types",
@@ -238,7 +238,7 @@ def test_numpy_array_equality_comparator_equal_yes(
 ) -> None:
     comparator = NumpyArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -252,7 +252,7 @@ def test_numpy_array_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = NumpyArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -265,7 +265,7 @@ def test_numpy_array_equality_comparator_equal_false(
 ) -> None:
     comparator = NumpyArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -279,7 +279,7 @@ def test_numpy_array_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = NumpyArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -307,7 +307,7 @@ def test_numpy_array_equality_comparator_equal_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert NumpyArrayEqualityComparator().equal(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 
@@ -367,7 +367,7 @@ def test_numpy_masked_array_equality_comparator_equal_yes(
 ) -> None:
     comparator = NumpyMaskedArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -381,7 +381,7 @@ def test_numpy_masked_array_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = NumpyMaskedArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -394,7 +394,7 @@ def test_numpy_masked_array_equality_comparator_equal_false(
 ) -> None:
     comparator = NumpyMaskedArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -408,7 +408,7 @@ def test_numpy_masked_array_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = NumpyMaskedArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 

--- a/tests/unit/equality/comparators/test_numpy.py
+++ b/tests/unit/equality/comparators/test_numpy.py
@@ -238,7 +238,7 @@ def test_numpy_array_equality_comparator_equal_yes(
 ) -> None:
     comparator = NumpyArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -252,7 +252,7 @@ def test_numpy_array_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = NumpyArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -265,7 +265,7 @@ def test_numpy_array_equality_comparator_equal_false(
 ) -> None:
     comparator = NumpyArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -279,7 +279,7 @@ def test_numpy_array_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = NumpyArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -291,8 +291,8 @@ def test_numpy_array_equality_comparator_equal_nan_true(
     config.equal_nan = equal_nan
     assert (
         NumpyArrayEqualityComparator().equal(
-            object1=np.array([0.0, np.nan, np.nan, 1.2]),
-            object2=np.array([0.0, np.nan, np.nan, 1.2]),
+            actual=np.array([0.0, np.nan, np.nan, 1.2]),
+            expected=np.array([0.0, np.nan, np.nan, 1.2]),
             config=config,
         )
         == equal_nan
@@ -307,7 +307,7 @@ def test_numpy_array_equality_comparator_equal_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert NumpyArrayEqualityComparator().equal(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 
@@ -367,7 +367,7 @@ def test_numpy_masked_array_equality_comparator_equal_yes(
 ) -> None:
     comparator = NumpyMaskedArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -381,7 +381,7 @@ def test_numpy_masked_array_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = NumpyMaskedArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -394,7 +394,7 @@ def test_numpy_masked_array_equality_comparator_equal_false(
 ) -> None:
     comparator = NumpyMaskedArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -408,7 +408,7 @@ def test_numpy_masked_array_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = NumpyMaskedArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -420,8 +420,8 @@ def test_numpy_masked_array_equality_comparator_equal_nan(
     config.equal_nan = equal_nan
     assert (
         NumpyMaskedArrayEqualityComparator().equal(
-            object1=np.ma.array(data=[0.0, np.nan, np.nan, 1.2], mask=[0, 1, 0, 1]),
-            object2=np.ma.array(data=[0.0, np.nan, np.nan, 1.2], mask=[0, 1, 0, 1]),
+            actual=np.ma.array(data=[0.0, np.nan, np.nan, 1.2], mask=[0, 1, 0, 1]),
+            expected=np.ma.array(data=[0.0, np.nan, np.nan, 1.2], mask=[0, 1, 0, 1]),
             config=config,
         )
         == equal_nan

--- a/tests/unit/equality/comparators/test_pandas.py
+++ b/tests/unit/equality/comparators/test_pandas.py
@@ -30,22 +30,22 @@ def config() -> EqualityConfig:
 PANDAS_DATAFRAME_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=pandas.DataFrame({}),
-            object2=pandas.DataFrame({}),
+            actual=pandas.DataFrame({}),
+            expected=pandas.DataFrame({}),
         ),
         id="0 column",
     ),
     pytest.param(
         ExamplePair(
-            object1=pandas.DataFrame({"col": [1, 2, 3]}),
-            object2=pandas.DataFrame({"col": [1, 2, 3]}),
+            actual=pandas.DataFrame({"col": [1, 2, 3]}),
+            expected=pandas.DataFrame({"col": [1, 2, 3]}),
         ),
         id="1 column",
     ),
     pytest.param(
         ExamplePair(
-            object1=pandas.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]}),
-            object2=pandas.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]}),
+            actual=pandas.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]}),
+            expected=pandas.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]}),
         ),
         id="2 columns",
     ),
@@ -54,24 +54,24 @@ PANDAS_DATAFRAME_EQUAL = [
 PANDAS_DATAFRAME_NOT_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=pandas.DataFrame({"col": [1, 2, 3]}),
-            object2=pandas.DataFrame({"col": [1, 2, 4]}),
+            actual=pandas.DataFrame({"col": [1, 2, 3]}),
+            expected=pandas.DataFrame({"col": [1, 2, 4]}),
             expected_message="pandas.DataFrames have different elements:",
         ),
         id="different values",
     ),
     pytest.param(
         ExamplePair(
-            object1=pandas.DataFrame({"col1": [1, 2, 3]}),
-            object2=pandas.DataFrame({"col2": [1, 2, 3]}),
+            actual=pandas.DataFrame({"col1": [1, 2, 3]}),
+            expected=pandas.DataFrame({"col2": [1, 2, 3]}),
             expected_message="pandas.DataFrames have different elements:",
         ),
         id="different column names",
     ),
     pytest.param(
         ExamplePair(
-            object1=pandas.DataFrame({"col1": [1, 2, 3]}),
-            object2=pandas.Series([1, 2, 3]),
+            actual=pandas.DataFrame({"col1": [1, 2, 3]}),
+            expected=pandas.Series([1, 2, 3]),
             expected_message="objects have different types:",
         ),
         id="different column names",
@@ -82,24 +82,24 @@ PANDAS_DATAFRAME_EQUAL_TOLERANCE = [
     # atol
     pytest.param(
         ExamplePair(
-            object1=pandas.DataFrame({"col": [1.0, 1.0, 1.0]}),
-            object2=pandas.DataFrame({"col": [1.5, 1.5, 0.5]}),
+            actual=pandas.DataFrame({"col": [1.0, 1.0, 1.0]}),
+            expected=pandas.DataFrame({"col": [1.5, 1.5, 0.5]}),
             atol=1.0,
         ),
         id="atol=1",
     ),
     pytest.param(
         ExamplePair(
-            object1=pandas.DataFrame({"col": [1.0, 1.0, 1.0]}),
-            object2=pandas.DataFrame({"col": [1.0, 1.05, 0.95]}),
+            actual=pandas.DataFrame({"col": [1.0, 1.0, 1.0]}),
+            expected=pandas.DataFrame({"col": [1.0, 1.05, 0.95]}),
             atol=0.1,
         ),
         id="atol=0.1",
     ),
     pytest.param(
         ExamplePair(
-            object1=pandas.DataFrame({"col": [1.0, 1.0, 1.0]}),
-            object2=pandas.DataFrame({"col": [1.0, 1.005, 0.995]}),
+            actual=pandas.DataFrame({"col": [1.0, 1.0, 1.0]}),
+            expected=pandas.DataFrame({"col": [1.0, 1.005, 0.995]}),
             atol=0.01,
         ),
         id="atol=0.01",
@@ -107,24 +107,24 @@ PANDAS_DATAFRAME_EQUAL_TOLERANCE = [
     # rtol
     pytest.param(
         ExamplePair(
-            object1=pandas.DataFrame({"col": [1.0, 1.0, 1.0]}),
-            object2=pandas.DataFrame({"col": [1.0, 1.5, 0.5]}),
+            actual=pandas.DataFrame({"col": [1.0, 1.0, 1.0]}),
+            expected=pandas.DataFrame({"col": [1.0, 1.5, 0.5]}),
             rtol=1.0,
         ),
         id="rtol=1",
     ),
     pytest.param(
         ExamplePair(
-            object1=pandas.DataFrame({"col": [1.0, 1.0, 1.0]}),
-            object2=pandas.DataFrame({"col": [1.0, 1.05, 0.95]}),
+            actual=pandas.DataFrame({"col": [1.0, 1.0, 1.0]}),
+            expected=pandas.DataFrame({"col": [1.0, 1.05, 0.95]}),
             rtol=0.1,
         ),
         id="rtol=0.1",
     ),
     pytest.param(
         ExamplePair(
-            object1=pandas.DataFrame({"col": [1.0, 1.0, 1.0]}),
-            object2=pandas.DataFrame({"col": [1.0, 1.005, 0.995]}),
+            actual=pandas.DataFrame({"col": [1.0, 1.0, 1.0]}),
+            expected=pandas.DataFrame({"col": [1.0, 1.005, 0.995]}),
             rtol=0.01,
         ),
         id="rtol=0.01",
@@ -134,16 +134,16 @@ PANDAS_DATAFRAME_EQUAL_TOLERANCE = [
 PANDAS_SERIES_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=pandas.Series(data=[], dtype=object),
-            object2=pandas.Series(data=[], dtype=object),
+            actual=pandas.Series(data=[], dtype=object),
+            expected=pandas.Series(data=[], dtype=object),
         ),
         id="empty",
     ),
     pytest.param(
-        ExamplePair(object1=pandas.Series([1, 2, 3]), object2=pandas.Series([1, 2, 3])), id="int"
+        ExamplePair(actual=pandas.Series([1, 2, 3]), expected=pandas.Series([1, 2, 3])), id="int"
     ),
     pytest.param(
-        ExamplePair(object1=pandas.Series(["a", "b", "c"]), object2=pandas.Series(["a", "b", "c"])),
+        ExamplePair(actual=pandas.Series(["a", "b", "c"]), expected=pandas.Series(["a", "b", "c"])),
         id="str",
     ),
 ]
@@ -151,32 +151,32 @@ PANDAS_SERIES_EQUAL = [
 PANDAS_SERIES_NOT_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=pandas.Series([1, 2, 3]),
-            object2=pandas.Series([1, 2, 4]),
+            actual=pandas.Series([1, 2, 3]),
+            expected=pandas.Series([1, 2, 4]),
             expected_message="pandas.Series have different elements:",
         ),
         id="different value",
     ),
     pytest.param(
         ExamplePair(
-            object1=pandas.Series([1, 2, 3]),
-            object2=pandas.Series([1, 2, 3, 4]),
+            actual=pandas.Series([1, 2, 3]),
+            expected=pandas.Series([1, 2, 3, 4]),
             expected_message="pandas.Series have different elements:",
         ),
         id="different shape",
     ),
     pytest.param(
         ExamplePair(
-            object1=pandas.Series([1, 2, 3]),
-            object2=pandas.Series([1.0, 2.0, 3.0]),
+            actual=pandas.Series([1, 2, 3]),
+            expected=pandas.Series([1.0, 2.0, 3.0]),
             expected_message="pandas.Series have different elements:",
         ),
         id="different data type",
     ),
     pytest.param(
         ExamplePair(
-            object1=pandas.Series([1, 2, 3]),
-            object2=42,
+            actual=pandas.Series([1, 2, 3]),
+            expected=42,
             expected_message="objects have different types:",
         ),
         id="different type",
@@ -187,24 +187,24 @@ PANDAS_SERIES_EQUAL_TOLERANCE = [
     # atol
     pytest.param(
         ExamplePair(
-            object1=pandas.Series([1.0, 1.0, 1.0]),
-            object2=pandas.Series([1.0, 1.5, 0.5]),
+            actual=pandas.Series([1.0, 1.0, 1.0]),
+            expected=pandas.Series([1.0, 1.5, 0.5]),
             atol=1.0,
         ),
         id="atol=1",
     ),
     pytest.param(
         ExamplePair(
-            object1=pandas.Series([1.0, 1.0, 1.0]),
-            object2=pandas.Series([1.0, 1.05, 0.95]),
+            actual=pandas.Series([1.0, 1.0, 1.0]),
+            expected=pandas.Series([1.0, 1.05, 0.95]),
             atol=0.1,
         ),
         id="atol=0.1",
     ),
     pytest.param(
         ExamplePair(
-            object1=pandas.Series([1.0, 1.0, 1.0]),
-            object2=pandas.Series([1.0, 1.005, 0.995]),
+            actual=pandas.Series([1.0, 1.0, 1.0]),
+            expected=pandas.Series([1.0, 1.005, 0.995]),
             atol=0.01,
         ),
         id="atol=0.01",
@@ -212,24 +212,24 @@ PANDAS_SERIES_EQUAL_TOLERANCE = [
     # rtol
     pytest.param(
         ExamplePair(
-            object1=pandas.Series([1.0, 1.0, 1.0]),
-            object2=pandas.Series([1.0, 1.5, 0.5]),
+            actual=pandas.Series([1.0, 1.0, 1.0]),
+            expected=pandas.Series([1.0, 1.5, 0.5]),
             rtol=1.0,
         ),
         id="rtol=1",
     ),
     pytest.param(
         ExamplePair(
-            object1=pandas.Series([1.0, 1.0, 1.0]),
-            object2=pandas.Series([1.0, 1.05, 0.95]),
+            actual=pandas.Series([1.0, 1.0, 1.0]),
+            expected=pandas.Series([1.0, 1.05, 0.95]),
             rtol=0.1,
         ),
         id="rtol=0.1",
     ),
     pytest.param(
         ExamplePair(
-            object1=pandas.Series([1.0, 1.0, 1.0]),
-            object2=pandas.Series([1.0, 1.005, 0.995]),
+            actual=pandas.Series([1.0, 1.0, 1.0]),
+            expected=pandas.Series([1.0, 1.005, 0.995]),
             rtol=0.01,
         ),
         id="rtol=0.01",
@@ -285,7 +285,7 @@ def test_pandas_dataframe_equality_comparator_equal_true(
 ) -> None:
     comparator = PandasDataFrameEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -299,7 +299,7 @@ def test_pandas_dataframe_equality_comparator_equal_true_show_difference(
     config.show_difference = True
     comparator = PandasDataFrameEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -312,7 +312,7 @@ def test_pandas_dataframe_equality_comparator_equal_false(
 ) -> None:
     comparator = PandasDataFrameEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -326,7 +326,7 @@ def test_pandas_dataframe_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = PandasDataFrameEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert caplog.messages[0].startswith(example.expected_message)
 
 
@@ -354,7 +354,7 @@ def test_pandas_dataframe_equality_comparator_equal_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert PandasDataFrameEqualityComparator().equal(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 
@@ -410,7 +410,7 @@ def test_pandas_series_equality_comparator_equal_true(
 ) -> None:
     comparator = PandasSeriesEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -424,7 +424,7 @@ def test_pandas_series_equality_comparator_equal_true_show_difference(
     config.show_difference = True
     comparator = PandasSeriesEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -437,7 +437,7 @@ def test_pandas_series_equality_comparator_equal_false(
 ) -> None:
     comparator = PandasSeriesEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -451,7 +451,7 @@ def test_pandas_series_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = PandasSeriesEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert caplog.messages[0].startswith(example.expected_message)
 
 
@@ -479,7 +479,7 @@ def test_pandas_series_equality_comparator_equal_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert PandasSeriesEqualityComparator().equal(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 

--- a/tests/unit/equality/comparators/test_pandas.py
+++ b/tests/unit/equality/comparators/test_pandas.py
@@ -285,7 +285,7 @@ def test_pandas_dataframe_equality_comparator_equal_true(
 ) -> None:
     comparator = PandasDataFrameEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -299,7 +299,7 @@ def test_pandas_dataframe_equality_comparator_equal_true_show_difference(
     config.show_difference = True
     comparator = PandasDataFrameEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -312,7 +312,7 @@ def test_pandas_dataframe_equality_comparator_equal_false(
 ) -> None:
     comparator = PandasDataFrameEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -326,7 +326,7 @@ def test_pandas_dataframe_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = PandasDataFrameEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert caplog.messages[0].startswith(example.expected_message)
 
 
@@ -338,8 +338,8 @@ def test_pandas_dataframe_equality_comparator_equal_nan(
     config.equal_nan = equal_nan
     assert (
         PandasDataFrameEqualityComparator().equal(
-            object1=pandas.DataFrame({"col": [1, float("nan"), 3]}),
-            object2=pandas.DataFrame({"col": [1, float("nan"), 3]}),
+            actual=pandas.DataFrame({"col": [1, float("nan"), 3]}),
+            expected=pandas.DataFrame({"col": [1, float("nan"), 3]}),
             config=config,
         )
         == equal_nan
@@ -354,7 +354,7 @@ def test_pandas_dataframe_equality_comparator_equal_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert PandasDataFrameEqualityComparator().equal(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 
@@ -410,7 +410,7 @@ def test_pandas_series_equality_comparator_equal_true(
 ) -> None:
     comparator = PandasSeriesEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -424,7 +424,7 @@ def test_pandas_series_equality_comparator_equal_true_show_difference(
     config.show_difference = True
     comparator = PandasSeriesEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -437,7 +437,7 @@ def test_pandas_series_equality_comparator_equal_false(
 ) -> None:
     comparator = PandasSeriesEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -451,7 +451,7 @@ def test_pandas_series_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = PandasSeriesEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert caplog.messages[0].startswith(example.expected_message)
 
 
@@ -463,8 +463,8 @@ def test_pandas_series_equality_comparator_equal_nan(
     config.equal_nan = equal_nan
     assert (
         PandasSeriesEqualityComparator().equal(
-            object1=pandas.Series([0.0, float("nan"), float("nan"), 1.2]),
-            object2=pandas.Series([0.0, float("nan"), float("nan"), 1.2]),
+            actual=pandas.Series([0.0, float("nan"), float("nan"), 1.2]),
+            expected=pandas.Series([0.0, float("nan"), float("nan"), 1.2]),
             config=config,
         )
         == equal_nan
@@ -479,7 +479,7 @@ def test_pandas_series_equality_comparator_equal_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert PandasSeriesEqualityComparator().equal(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 

--- a/tests/unit/equality/comparators/test_polars.py
+++ b/tests/unit/equality/comparators/test_polars.py
@@ -287,7 +287,7 @@ def test_polars_dataframe_equality_comparator_equal_true(
 ) -> None:
     comparator = PolarsDataFrameEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -301,7 +301,7 @@ def test_polars_dataframe_equality_comparator_equal_true_show_difference(
     config.show_difference = True
     comparator = PolarsDataFrameEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -314,7 +314,7 @@ def test_polars_dataframe_equality_comparator_equal_false(
 ) -> None:
     comparator = PolarsDataFrameEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -328,7 +328,7 @@ def test_polars_dataframe_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = PolarsDataFrameEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert caplog.messages[0].startswith(example.expected_message)
 
 
@@ -340,8 +340,8 @@ def test_polars_dataframe_equality_comparator_equal_nan(
     config.equal_nan = equal_nan
     assert (
         PolarsDataFrameEqualityComparator().equal(
-            object1=polars.DataFrame({"col": [1, float("nan"), 3]}),
-            object2=polars.DataFrame({"col": [1, float("nan"), 3]}),
+            actual=polars.DataFrame({"col": [1, float("nan"), 3]}),
+            expected=polars.DataFrame({"col": [1, float("nan"), 3]}),
             config=config,
         )
         == equal_nan
@@ -356,7 +356,7 @@ def test_polars_dataframe_equality_comparator_equal_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert PolarsDataFrameEqualityComparator().equal(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 
@@ -412,7 +412,7 @@ def test_polars_series_equality_comparator_equal_true(
 ) -> None:
     comparator = PolarsSeriesEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -426,7 +426,7 @@ def test_polars_series_equality_comparator_equal_true_show_difference(
     config.show_difference = True
     comparator = PolarsSeriesEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -439,7 +439,7 @@ def test_polars_series_equality_comparator_equal_false(
 ) -> None:
     comparator = PolarsSeriesEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -453,7 +453,7 @@ def test_polars_series_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = PolarsSeriesEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert caplog.messages[0].startswith(example.expected_message)
 
 
@@ -465,8 +465,8 @@ def test_polars_series_equality_comparator_equal_nan(
     config.equal_nan = equal_nan
     assert (
         PolarsSeriesEqualityComparator().equal(
-            object1=polars.Series([0.0, float("nan"), float("nan"), 1.2]),
-            object2=polars.Series([0.0, float("nan"), float("nan"), 1.2]),
+            actual=polars.Series([0.0, float("nan"), float("nan"), 1.2]),
+            expected=polars.Series([0.0, float("nan"), float("nan"), 1.2]),
             config=config,
         )
         == equal_nan
@@ -481,7 +481,7 @@ def test_polars_series_equality_comparator_equal_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert PolarsSeriesEqualityComparator().equal(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 

--- a/tests/unit/equality/comparators/test_polars.py
+++ b/tests/unit/equality/comparators/test_polars.py
@@ -30,22 +30,22 @@ def config() -> EqualityConfig:
 POLARS_DATAFRAME_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=polars.DataFrame({}),
-            object2=polars.DataFrame({}),
+            actual=polars.DataFrame({}),
+            expected=polars.DataFrame({}),
         ),
         id="0 column",
     ),
     pytest.param(
         ExamplePair(
-            object1=polars.DataFrame({"col": [1, 2, 3]}),
-            object2=polars.DataFrame({"col": [1, 2, 3]}),
+            actual=polars.DataFrame({"col": [1, 2, 3]}),
+            expected=polars.DataFrame({"col": [1, 2, 3]}),
         ),
         id="1 column",
     ),
     pytest.param(
         ExamplePair(
-            object1=polars.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]}),
-            object2=polars.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]}),
+            actual=polars.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]}),
+            expected=polars.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]}),
         ),
         id="2 columns",
     ),
@@ -54,24 +54,24 @@ POLARS_DATAFRAME_EQUAL = [
 POLARS_DATAFRAME_NOT_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=polars.DataFrame({"col": [1, 2, 3]}),
-            object2=polars.DataFrame({"col": [1, 2, 4]}),
+            actual=polars.DataFrame({"col": [1, 2, 3]}),
+            expected=polars.DataFrame({"col": [1, 2, 4]}),
             expected_message="polars.DataFrames have different elements:",
         ),
         id="different values",
     ),
     pytest.param(
         ExamplePair(
-            object1=polars.DataFrame({"col1": [1, 2, 3]}),
-            object2=polars.DataFrame({"col2": [1, 2, 3]}),
+            actual=polars.DataFrame({"col1": [1, 2, 3]}),
+            expected=polars.DataFrame({"col2": [1, 2, 3]}),
             expected_message="polars.DataFrames have different elements:",
         ),
         id="different column names",
     ),
     pytest.param(
         ExamplePair(
-            object1=polars.DataFrame({"col1": [1, 2, 3]}),
-            object2=polars.Series([1, 2, 3]),
+            actual=polars.DataFrame({"col1": [1, 2, 3]}),
+            expected=polars.Series([1, 2, 3]),
             expected_message="objects have different types:",
         ),
         id="different column names",
@@ -83,24 +83,24 @@ POLARS_DATAFRAME_EQUAL_TOLERANCE = [
     # atol
     pytest.param(
         ExamplePair(
-            object1=polars.DataFrame({"col": [1.0, 1.0, 1.0]}),
-            object2=polars.DataFrame({"col": [1.5, 1.5, 0.5]}),
+            actual=polars.DataFrame({"col": [1.0, 1.0, 1.0]}),
+            expected=polars.DataFrame({"col": [1.5, 1.5, 0.5]}),
             atol=1.0,
         ),
         id="atol=1",
     ),
     pytest.param(
         ExamplePair(
-            object1=polars.DataFrame({"col": [1.0, 1.0, 1.0]}),
-            object2=polars.DataFrame({"col": [1.0, 1.05, 0.95]}),
+            actual=polars.DataFrame({"col": [1.0, 1.0, 1.0]}),
+            expected=polars.DataFrame({"col": [1.0, 1.05, 0.95]}),
             atol=0.1,
         ),
         id="atol=0.1",
     ),
     pytest.param(
         ExamplePair(
-            object1=polars.DataFrame({"col": [1.0, 1.0, 1.0]}),
-            object2=polars.DataFrame({"col": [1.0, 1.005, 0.995]}),
+            actual=polars.DataFrame({"col": [1.0, 1.0, 1.0]}),
+            expected=polars.DataFrame({"col": [1.0, 1.005, 0.995]}),
             atol=0.01,
         ),
         id="atol=0.01",
@@ -108,24 +108,24 @@ POLARS_DATAFRAME_EQUAL_TOLERANCE = [
     # rtol
     pytest.param(
         ExamplePair(
-            object1=polars.DataFrame({"col": [1.0, 1.0, 1.0]}),
-            object2=polars.DataFrame({"col": [1.0, 1.5, 0.5]}),
+            actual=polars.DataFrame({"col": [1.0, 1.0, 1.0]}),
+            expected=polars.DataFrame({"col": [1.0, 1.5, 0.5]}),
             rtol=1.0,
         ),
         id="rtol=1",
     ),
     pytest.param(
         ExamplePair(
-            object1=polars.DataFrame({"col": [1.0, 1.0, 1.0]}),
-            object2=polars.DataFrame({"col": [1.0, 1.05, 0.95]}),
+            actual=polars.DataFrame({"col": [1.0, 1.0, 1.0]}),
+            expected=polars.DataFrame({"col": [1.0, 1.05, 0.95]}),
             rtol=0.1,
         ),
         id="rtol=0.1",
     ),
     pytest.param(
         ExamplePair(
-            object1=polars.DataFrame({"col": [1.0, 1.0, 1.0]}),
-            object2=polars.DataFrame({"col": [1.0, 1.005, 0.995]}),
+            actual=polars.DataFrame({"col": [1.0, 1.0, 1.0]}),
+            expected=polars.DataFrame({"col": [1.0, 1.005, 0.995]}),
             rtol=0.01,
         ),
         id="rtol=0.01",
@@ -136,16 +136,16 @@ POLARS_DATAFRAME_EQUAL_TOLERANCE = [
 POLARS_SERIES_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=polars.Series([]),
-            object2=polars.Series([]),
+            actual=polars.Series([]),
+            expected=polars.Series([]),
         ),
         id="empty",
     ),
     pytest.param(
-        ExamplePair(object1=polars.Series([1, 2, 3]), object2=polars.Series([1, 2, 3])), id="int"
+        ExamplePair(actual=polars.Series([1, 2, 3]), expected=polars.Series([1, 2, 3])), id="int"
     ),
     pytest.param(
-        ExamplePair(object1=polars.Series(["a", "b", "c"]), object2=polars.Series(["a", "b", "c"])),
+        ExamplePair(actual=polars.Series(["a", "b", "c"]), expected=polars.Series(["a", "b", "c"])),
         id="str",
     ),
 ]
@@ -153,32 +153,32 @@ POLARS_SERIES_EQUAL = [
 POLARS_SERIES_NOT_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=polars.Series([1, 2, 3]),
-            object2=polars.Series([1, 2, 4]),
+            actual=polars.Series([1, 2, 3]),
+            expected=polars.Series([1, 2, 4]),
             expected_message="polars.Series have different elements:",
         ),
         id="different value",
     ),
     pytest.param(
         ExamplePair(
-            object1=polars.Series([1, 2, 3]),
-            object2=polars.Series([1, 2, 3, 4]),
+            actual=polars.Series([1, 2, 3]),
+            expected=polars.Series([1, 2, 3, 4]),
             expected_message="polars.Series have different elements:",
         ),
         id="different shape",
     ),
     pytest.param(
         ExamplePair(
-            object1=polars.Series([1, 2, 3]),
-            object2=polars.Series([1.0, 2.0, 3.0]),
+            actual=polars.Series([1, 2, 3]),
+            expected=polars.Series([1.0, 2.0, 3.0]),
             expected_message="polars.Series have different elements:",
         ),
         id="different data type",
     ),
     pytest.param(
         ExamplePair(
-            object1=polars.Series([1, 2, 3]),
-            object2=42,
+            actual=polars.Series([1, 2, 3]),
+            expected=42,
             expected_message="objects have different types:",
         ),
         id="different type",
@@ -189,24 +189,24 @@ POLARS_SERIES_EQUAL_TOLERANCE = [
     # atol
     pytest.param(
         ExamplePair(
-            object1=polars.Series([1.0, 1.0, 1.0]),
-            object2=polars.Series([1.0, 1.5, 0.5]),
+            actual=polars.Series([1.0, 1.0, 1.0]),
+            expected=polars.Series([1.0, 1.5, 0.5]),
             atol=1.0,
         ),
         id="atol=1",
     ),
     pytest.param(
         ExamplePair(
-            object1=polars.Series([1.0, 1.0, 1.0]),
-            object2=polars.Series([1.0, 1.05, 0.95]),
+            actual=polars.Series([1.0, 1.0, 1.0]),
+            expected=polars.Series([1.0, 1.05, 0.95]),
             atol=0.1,
         ),
         id="atol=0.1",
     ),
     pytest.param(
         ExamplePair(
-            object1=polars.Series([1.0, 1.0, 1.0]),
-            object2=polars.Series([1.0, 1.005, 0.995]),
+            actual=polars.Series([1.0, 1.0, 1.0]),
+            expected=polars.Series([1.0, 1.005, 0.995]),
             atol=0.01,
         ),
         id="atol=0.01",
@@ -214,24 +214,24 @@ POLARS_SERIES_EQUAL_TOLERANCE = [
     # rtol
     pytest.param(
         ExamplePair(
-            object1=polars.Series([1.0, 1.0, 1.0]),
-            object2=polars.Series([1.0, 1.5, 0.5]),
+            actual=polars.Series([1.0, 1.0, 1.0]),
+            expected=polars.Series([1.0, 1.5, 0.5]),
             rtol=1.0,
         ),
         id="rtol=1",
     ),
     pytest.param(
         ExamplePair(
-            object1=polars.Series([1.0, 1.0, 1.0]),
-            object2=polars.Series([1.0, 1.05, 0.95]),
+            actual=polars.Series([1.0, 1.0, 1.0]),
+            expected=polars.Series([1.0, 1.05, 0.95]),
             rtol=0.1,
         ),
         id="rtol=0.1",
     ),
     pytest.param(
         ExamplePair(
-            object1=polars.Series([1.0, 1.0, 1.0]),
-            object2=polars.Series([1.0, 1.005, 0.995]),
+            actual=polars.Series([1.0, 1.0, 1.0]),
+            expected=polars.Series([1.0, 1.005, 0.995]),
             rtol=0.01,
         ),
         id="rtol=0.01",
@@ -287,7 +287,7 @@ def test_polars_dataframe_equality_comparator_equal_true(
 ) -> None:
     comparator = PolarsDataFrameEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -301,7 +301,7 @@ def test_polars_dataframe_equality_comparator_equal_true_show_difference(
     config.show_difference = True
     comparator = PolarsDataFrameEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -314,7 +314,7 @@ def test_polars_dataframe_equality_comparator_equal_false(
 ) -> None:
     comparator = PolarsDataFrameEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -328,7 +328,7 @@ def test_polars_dataframe_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = PolarsDataFrameEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert caplog.messages[0].startswith(example.expected_message)
 
 
@@ -356,7 +356,7 @@ def test_polars_dataframe_equality_comparator_equal_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert PolarsDataFrameEqualityComparator().equal(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 
@@ -412,7 +412,7 @@ def test_polars_series_equality_comparator_equal_true(
 ) -> None:
     comparator = PolarsSeriesEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -426,7 +426,7 @@ def test_polars_series_equality_comparator_equal_true_show_difference(
     config.show_difference = True
     comparator = PolarsSeriesEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -439,7 +439,7 @@ def test_polars_series_equality_comparator_equal_false(
 ) -> None:
     comparator = PolarsSeriesEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -453,7 +453,7 @@ def test_polars_series_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = PolarsSeriesEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert caplog.messages[0].startswith(example.expected_message)
 
 
@@ -481,7 +481,7 @@ def test_polars_series_equality_comparator_equal_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert PolarsSeriesEqualityComparator().equal(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 

--- a/tests/unit/equality/comparators/test_scalar.py
+++ b/tests/unit/equality/comparators/test_scalar.py
@@ -99,7 +99,7 @@ def test_scalar_equality_comparator_equal_yes(
 ) -> None:
     comparator = ScalarEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -112,7 +112,7 @@ def test_scalar_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = ScalarEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -124,7 +124,7 @@ def test_scalar_equality_comparator_equal_false(
 ) -> None:
     comparator = ScalarEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -137,7 +137,7 @@ def test_scalar_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = ScalarEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -146,8 +146,8 @@ def test_scalar_equality_comparator_equal_nan(config: EqualityConfig, equal_nan:
     config.equal_nan = equal_nan
     assert (
         ScalarEqualityComparator().equal(
-            object1=float("nan"),
-            object2=float("nan"),
+            actual=float("nan"),
+            expected=float("nan"),
             config=config,
         )
         == equal_nan
@@ -161,7 +161,7 @@ def test_scalar_equality_comparator_equal_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert ScalarEqualityComparator().equal(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 

--- a/tests/unit/equality/comparators/test_scalar.py
+++ b/tests/unit/equality/comparators/test_scalar.py
@@ -19,21 +19,21 @@ def config() -> EqualityConfig:
 
 
 FLOAT_EQUAL = [
-    pytest.param(ExamplePair(object1=4.2, object2=4.2), id="positive"),
-    pytest.param(ExamplePair(object1=0.0, object2=0.0), id="zero"),
-    pytest.param(ExamplePair(object1=-4.2, object2=-4.2), id="negative"),
-    pytest.param(ExamplePair(object1=float("inf"), object2=float("inf")), id="infinity"),
-    pytest.param(ExamplePair(object1=float("-inf"), object2=float("-inf")), id="-infinity"),
+    pytest.param(ExamplePair(actual=4.2, expected=4.2), id="positive"),
+    pytest.param(ExamplePair(actual=0.0, expected=0.0), id="zero"),
+    pytest.param(ExamplePair(actual=-4.2, expected=-4.2), id="negative"),
+    pytest.param(ExamplePair(actual=float("inf"), expected=float("inf")), id="infinity"),
+    pytest.param(ExamplePair(actual=float("-inf"), expected=float("-inf")), id="-infinity"),
 ]
 
 
 FLOAT_NOT_EQUAL = [
     pytest.param(
-        ExamplePair(object1=4.2, object2=1.0, expected_message="numbers are not equal:"),
+        ExamplePair(actual=4.2, expected=1.0, expected_message="numbers are not equal:"),
         id="different values",
     ),
     pytest.param(
-        ExamplePair(object1=4.2, object2="meow", expected_message="objects have different types:"),
+        ExamplePair(actual=4.2, expected="meow", expected_message="objects have different types:"),
         id="different types",
     ),
 ]
@@ -44,21 +44,21 @@ SCALAR_NOT_EQUAL = FLOAT_NOT_EQUAL
 
 SCALAR_EQUAL_TOLERANCE = [
     # atol
-    pytest.param(ExamplePair(object1=0, object2=1, atol=1.0), id="integer 0 atol=1"),
-    pytest.param(ExamplePair(object1=1, object2=0, atol=1.0), id="integer 1 atol=1"),
-    pytest.param(ExamplePair(object1=1, object2=2, atol=1.0), id="integer 2 atol=1"),
-    pytest.param(ExamplePair(object1=1, object2=5, atol=10.0), id="integer 1 atol=10"),
-    pytest.param(ExamplePair(object1=1.0, object2=1.0001, atol=1e-3), id="float + atol=1e-3"),
-    pytest.param(ExamplePair(object1=1.0, object2=0.9999, atol=1e-3), id="float - atol=1e-3"),
-    pytest.param(ExamplePair(object1=True, object2=False, atol=1.0), id="bool - atol=1"),
+    pytest.param(ExamplePair(actual=0, expected=1, atol=1.0), id="integer 0 atol=1"),
+    pytest.param(ExamplePair(actual=1, expected=0, atol=1.0), id="integer 1 atol=1"),
+    pytest.param(ExamplePair(actual=1, expected=2, atol=1.0), id="integer 2 atol=1"),
+    pytest.param(ExamplePair(actual=1, expected=5, atol=10.0), id="integer 1 atol=10"),
+    pytest.param(ExamplePair(actual=1.0, expected=1.0001, atol=1e-3), id="float + atol=1e-3"),
+    pytest.param(ExamplePair(actual=1.0, expected=0.9999, atol=1e-3), id="float - atol=1e-3"),
+    pytest.param(ExamplePair(actual=True, expected=False, atol=1.0), id="bool - atol=1"),
     # rtol
-    pytest.param(ExamplePair(object1=0, object2=1, rtol=1.0), id="integer 0 rtol=1"),
-    pytest.param(ExamplePair(object1=1, object2=0, rtol=1.0), id="integer 1 rtol=1"),
-    pytest.param(ExamplePair(object1=1, object2=2, rtol=1.0), id="integer 2 rtol=1"),
-    pytest.param(ExamplePair(object1=1, object2=5, rtol=10.0), id="integer 1 rtol=10"),
-    pytest.param(ExamplePair(object1=1.0, object2=1.0001, rtol=1e-3), id="float + rtol=1e-3"),
-    pytest.param(ExamplePair(object1=1.0, object2=0.9999, rtol=1e-3), id="float - rtol=1e-3"),
-    pytest.param(ExamplePair(object1=True, object2=False, rtol=1.0), id="bool - rtol=1"),
+    pytest.param(ExamplePair(actual=0, expected=1, rtol=1.0), id="integer 0 rtol=1"),
+    pytest.param(ExamplePair(actual=1, expected=0, rtol=1.0), id="integer 1 rtol=1"),
+    pytest.param(ExamplePair(actual=1, expected=2, rtol=1.0), id="integer 2 rtol=1"),
+    pytest.param(ExamplePair(actual=1, expected=5, rtol=10.0), id="integer 1 rtol=10"),
+    pytest.param(ExamplePair(actual=1.0, expected=1.0001, rtol=1e-3), id="float + rtol=1e-3"),
+    pytest.param(ExamplePair(actual=1.0, expected=0.9999, rtol=1e-3), id="float - rtol=1e-3"),
+    pytest.param(ExamplePair(actual=True, expected=False, rtol=1.0), id="bool - rtol=1"),
 ]
 
 
@@ -99,7 +99,7 @@ def test_scalar_equality_comparator_equal_yes(
 ) -> None:
     comparator = ScalarEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -112,7 +112,7 @@ def test_scalar_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = ScalarEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -124,7 +124,7 @@ def test_scalar_equality_comparator_equal_false(
 ) -> None:
     comparator = ScalarEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -137,7 +137,7 @@ def test_scalar_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = ScalarEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -161,7 +161,7 @@ def test_scalar_equality_comparator_equal_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert ScalarEqualityComparator().equal(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 

--- a/tests/unit/equality/comparators/test_torch.py
+++ b/tests/unit/equality/comparators/test_torch.py
@@ -377,7 +377,7 @@ def test_tensor_packed_sequence_equality_comparator_equal_yes(
 ) -> None:
     comparator = TorchPackedSequenceEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -391,7 +391,7 @@ def test_tensor_packed_sequence_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = TorchPackedSequenceEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -404,7 +404,7 @@ def test_tensor_packed_sequence_equality_comparator_equal_false(
 ) -> None:
     comparator = TorchPackedSequenceEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -418,7 +418,7 @@ def test_tensor_packed_sequence_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = TorchPackedSequenceEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -504,7 +504,7 @@ def test_torch_tensor_equality_comparator_equal_yes(
 ) -> None:
     comparator = TorchTensorEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -518,7 +518,7 @@ def test_torch_tensor_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = TorchTensorEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -531,7 +531,7 @@ def test_torch_tensor_equality_comparator_equal_false(
 ) -> None:
     comparator = TorchTensorEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -545,7 +545,7 @@ def test_torch_tensor_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = TorchTensorEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -589,8 +589,8 @@ def test_torch_tensor_equality_comparator_equal_nan_true(
     config.equal_nan = equal_nan
     assert (
         TorchTensorEqualityComparator().equal(
-            object1=torch.tensor([0.0, float("nan"), float("nan"), 1.2]),
-            object2=torch.tensor([0.0, float("nan"), float("nan"), 1.2]),
+            actual=torch.tensor([0.0, float("nan"), float("nan"), 1.2]),
+            expected=torch.tensor([0.0, float("nan"), float("nan"), 1.2]),
             config=config,
         )
         == equal_nan
@@ -605,7 +605,7 @@ def test_torch_tensor_equality_comparator_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert TorchTensorEqualityComparator().equal(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 

--- a/tests/unit/equality/comparators/test_torch.py
+++ b/tests/unit/equality/comparators/test_torch.py
@@ -30,12 +30,12 @@ def config() -> EqualityConfig:
 TORCH_PACKED_SEQUENCE_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=torch.nn.utils.rnn.pack_padded_sequence(
+            actual=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.arange(10, dtype=torch.float).view(2, 5),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
             ),
-            object2=torch.nn.utils.rnn.pack_padded_sequence(
+            expected=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.arange(10, dtype=torch.float).view(2, 5),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
@@ -45,12 +45,12 @@ TORCH_PACKED_SEQUENCE_EQUAL = [
     ),
     pytest.param(
         ExamplePair(
-            object1=torch.nn.utils.rnn.pack_padded_sequence(
+            actual=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.arange(10, dtype=torch.long).view(2, 5),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
             ),
-            object2=torch.nn.utils.rnn.pack_padded_sequence(
+            expected=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.arange(10, dtype=torch.long).view(2, 5),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
@@ -62,12 +62,12 @@ TORCH_PACKED_SEQUENCE_EQUAL = [
 TORCH_PACKED_SEQUENCE_NOT_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=torch.nn.utils.rnn.pack_padded_sequence(
+            actual=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.arange(10, dtype=torch.float).view(2, 5),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
             ),
-            object2=torch.nn.utils.rnn.pack_padded_sequence(
+            expected=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.arange(10).view(2, 5).add(1).float(),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
@@ -78,13 +78,13 @@ TORCH_PACKED_SEQUENCE_NOT_EQUAL = [
     ),
     pytest.param(
         ExamplePair(
-            object1=torch.nn.utils.rnn.PackedSequence(
+            actual=torch.nn.utils.rnn.PackedSequence(
                 data=torch.tensor([0.0, 5.0, 1.0, 6.0, 2.0, 7.0, 3.0, 4.0]),
                 batch_sizes=torch.tensor([2, 2, 2, 1, 1]),
                 sorted_indices=None,
                 unsorted_indices=None,
             ),
-            object2=torch.nn.utils.rnn.PackedSequence(
+            expected=torch.nn.utils.rnn.PackedSequence(
                 data=torch.tensor([0.0, 5.0, 1.0, 6.0, 2.0, 7.0, 3.0, 4.0]),
                 batch_sizes=torch.tensor([2, 2, 2, 2, 0]),
                 sorted_indices=None,
@@ -96,13 +96,13 @@ TORCH_PACKED_SEQUENCE_NOT_EQUAL = [
     ),
     pytest.param(
         ExamplePair(
-            object1=torch.nn.utils.rnn.PackedSequence(
+            actual=torch.nn.utils.rnn.PackedSequence(
                 data=torch.tensor([0.0, 5.0, 1.0, 6.0, 2.0, 7.0, 3.0, 4.0]),
                 batch_sizes=torch.tensor([2, 2, 2, 1, 1]),
                 sorted_indices=torch.tensor([0, 1]),
                 unsorted_indices=None,
             ),
-            object2=torch.nn.utils.rnn.PackedSequence(
+            expected=torch.nn.utils.rnn.PackedSequence(
                 data=torch.tensor([0.0, 5.0, 1.0, 6.0, 2.0, 7.0, 3.0, 4.0]),
                 batch_sizes=torch.tensor([2, 2, 2, 1, 1]),
                 sorted_indices=None,
@@ -114,13 +114,13 @@ TORCH_PACKED_SEQUENCE_NOT_EQUAL = [
     ),
     pytest.param(
         ExamplePair(
-            object1=torch.nn.utils.rnn.PackedSequence(
+            actual=torch.nn.utils.rnn.PackedSequence(
                 data=torch.tensor([0.0, 5.0, 1.0, 6.0, 2.0, 7.0, 3.0, 4.0]),
                 batch_sizes=torch.tensor([2, 2, 2, 1, 1]),
                 sorted_indices=None,
                 unsorted_indices=torch.tensor([0, 1]),
             ),
-            object2=torch.nn.utils.rnn.PackedSequence(
+            expected=torch.nn.utils.rnn.PackedSequence(
                 data=torch.tensor([0.0, 5.0, 1.0, 6.0, 2.0, 7.0, 3.0, 4.0]),
                 batch_sizes=torch.tensor([2, 2, 2, 1, 1]),
                 sorted_indices=None,
@@ -132,12 +132,12 @@ TORCH_PACKED_SEQUENCE_NOT_EQUAL = [
     ),
     pytest.param(
         ExamplePair(
-            object1=torch.nn.utils.rnn.pack_padded_sequence(
+            actual=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.arange(10, dtype=torch.float).view(2, 5),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
             ),
-            object2=torch.arange(10, dtype=torch.float).view(2, 5),
+            expected=torch.arange(10, dtype=torch.float).view(2, 5),
             expected_message="objects have different types:",
         ),
         id="different types",
@@ -147,12 +147,12 @@ TORCH_PACKED_SEQUENCE_EQUAL_TOLERANCE = [
     # atol
     pytest.param(
         ExamplePair(
-            object1=torch.nn.utils.rnn.pack_padded_sequence(
+            actual=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.ones(2, 5),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
             ),
-            object2=torch.nn.utils.rnn.pack_padded_sequence(
+            expected=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.full(size=(2, 5), fill_value=1.5),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
@@ -163,12 +163,12 @@ TORCH_PACKED_SEQUENCE_EQUAL_TOLERANCE = [
     ),
     pytest.param(
         ExamplePair(
-            object1=torch.nn.utils.rnn.pack_padded_sequence(
+            actual=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.ones(2, 5),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
             ),
-            object2=torch.nn.utils.rnn.pack_padded_sequence(
+            expected=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.full(size=(2, 5), fill_value=1.05),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
@@ -179,12 +179,12 @@ TORCH_PACKED_SEQUENCE_EQUAL_TOLERANCE = [
     ),
     pytest.param(
         ExamplePair(
-            object1=torch.nn.utils.rnn.pack_padded_sequence(
+            actual=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.ones(2, 5),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
             ),
-            object2=torch.nn.utils.rnn.pack_padded_sequence(
+            expected=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.full(size=(2, 5), fill_value=1.005),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
@@ -196,12 +196,12 @@ TORCH_PACKED_SEQUENCE_EQUAL_TOLERANCE = [
     # rtol
     pytest.param(
         ExamplePair(
-            object1=torch.nn.utils.rnn.pack_padded_sequence(
+            actual=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.ones(2, 5),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
             ),
-            object2=torch.nn.utils.rnn.pack_padded_sequence(
+            expected=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.full(size=(2, 5), fill_value=1.5),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
@@ -212,12 +212,12 @@ TORCH_PACKED_SEQUENCE_EQUAL_TOLERANCE = [
     ),
     pytest.param(
         ExamplePair(
-            object1=torch.nn.utils.rnn.pack_padded_sequence(
+            actual=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.ones(2, 5),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
             ),
-            object2=torch.nn.utils.rnn.pack_padded_sequence(
+            expected=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.full(size=(2, 5), fill_value=1.05),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
@@ -228,12 +228,12 @@ TORCH_PACKED_SEQUENCE_EQUAL_TOLERANCE = [
     ),
     pytest.param(
         ExamplePair(
-            object1=torch.nn.utils.rnn.pack_padded_sequence(
+            actual=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.ones(2, 5),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
             ),
-            object2=torch.nn.utils.rnn.pack_padded_sequence(
+            expected=torch.nn.utils.rnn.pack_padded_sequence(
                 input=torch.full(size=(2, 5), fill_value=1.005),
                 lengths=torch.tensor([5, 3], dtype=torch.long),
                 batch_first=True,
@@ -248,48 +248,48 @@ TORCH_PACKED_SEQUENCE_EQUAL_TOLERANCE = [
 TORCH_TENSOR_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=torch.ones(2, 3, dtype=torch.float), object2=torch.ones(2, 3, dtype=torch.float)
+            actual=torch.ones(2, 3, dtype=torch.float), expected=torch.ones(2, 3, dtype=torch.float)
         ),
         id="float dtype",
     ),
     pytest.param(
         ExamplePair(
-            object1=torch.ones(2, 3, dtype=torch.long), object2=torch.ones(2, 3, dtype=torch.long)
+            actual=torch.ones(2, 3, dtype=torch.long), expected=torch.ones(2, 3, dtype=torch.long)
         ),
         id="long dtype",
     ),
-    pytest.param(ExamplePair(object1=torch.ones(6), object2=torch.ones(6)), id="1d tensor"),
-    pytest.param(ExamplePair(object1=torch.ones(2, 3), object2=torch.ones(2, 3)), id="2d tensor"),
+    pytest.param(ExamplePair(actual=torch.ones(6), expected=torch.ones(6)), id="1d tensor"),
+    pytest.param(ExamplePair(actual=torch.ones(2, 3), expected=torch.ones(2, 3)), id="2d tensor"),
 ]
 TORCH_TENSOR_NOT_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=torch.ones(2, 3, dtype=torch.float),
-            object2=torch.ones(2, 3, dtype=torch.long),
+            actual=torch.ones(2, 3, dtype=torch.float),
+            expected=torch.ones(2, 3, dtype=torch.long),
             expected_message="objects have different data types:",
         ),
         id="different data types",
     ),
     pytest.param(
         ExamplePair(
-            object1=torch.ones(2, 3),
-            object2=torch.ones(6),
+            actual=torch.ones(2, 3),
+            expected=torch.ones(6),
             expected_message="objects have different shapes:",
         ),
         id="different shapes",
     ),
     pytest.param(
         ExamplePair(
-            object1=torch.ones(2, 3),
-            object2=torch.zeros(2, 3),
+            actual=torch.ones(2, 3),
+            expected=torch.zeros(2, 3),
             expected_message="torch.Tensors have different elements:",
         ),
         id="different values",
     ),
     pytest.param(
         ExamplePair(
-            object1=torch.ones(2, 3),
-            object2="meow",
+            actual=torch.ones(2, 3),
+            expected="meow",
             expected_message="objects have different types:",
         ),
         id="different types",
@@ -298,28 +298,28 @@ TORCH_TENSOR_NOT_EQUAL = [
 TORCH_TENSOR_EQUAL_TOLERANCE = [
     # atol
     pytest.param(
-        ExamplePair(object1=torch.ones(2, 3), object2=torch.full((2, 3), 1.5), atol=1.0),
+        ExamplePair(actual=torch.ones(2, 3), expected=torch.full((2, 3), 1.5), atol=1.0),
         id="atol=1",
     ),
     pytest.param(
-        ExamplePair(object1=torch.ones(2, 3), object2=torch.full((2, 3), 1.05), atol=0.1),
+        ExamplePair(actual=torch.ones(2, 3), expected=torch.full((2, 3), 1.05), atol=0.1),
         id="atol=0.1",
     ),
     pytest.param(
-        ExamplePair(object1=torch.ones(2, 3), object2=torch.full((2, 3), 1.005), atol=0.01),
+        ExamplePair(actual=torch.ones(2, 3), expected=torch.full((2, 3), 1.005), atol=0.01),
         id="atol=0.01",
     ),
     # rtol
     pytest.param(
-        ExamplePair(object1=torch.ones(2, 3), object2=torch.full((2, 3), 1.5), rtol=1.0),
+        ExamplePair(actual=torch.ones(2, 3), expected=torch.full((2, 3), 1.5), rtol=1.0),
         id="rtol=1",
     ),
     pytest.param(
-        ExamplePair(object1=torch.ones(2, 3), object2=torch.full((2, 3), 1.05), rtol=0.1),
+        ExamplePair(actual=torch.ones(2, 3), expected=torch.full((2, 3), 1.05), rtol=0.1),
         id="rtol=0.1",
     ),
     pytest.param(
-        ExamplePair(object1=torch.ones(2, 3), object2=torch.full((2, 3), 1.005), rtol=0.01),
+        ExamplePair(actual=torch.ones(2, 3), expected=torch.full((2, 3), 1.005), rtol=0.01),
         id="rtol=0.01",
     ),
 ]
@@ -377,7 +377,7 @@ def test_tensor_packed_sequence_equality_comparator_equal_yes(
 ) -> None:
     comparator = TorchPackedSequenceEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -391,7 +391,7 @@ def test_tensor_packed_sequence_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = TorchPackedSequenceEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -404,7 +404,7 @@ def test_tensor_packed_sequence_equality_comparator_equal_false(
 ) -> None:
     comparator = TorchPackedSequenceEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -418,7 +418,7 @@ def test_tensor_packed_sequence_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = TorchPackedSequenceEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -504,7 +504,7 @@ def test_torch_tensor_equality_comparator_equal_yes(
 ) -> None:
     comparator = TorchTensorEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -518,7 +518,7 @@ def test_torch_tensor_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = TorchTensorEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -531,7 +531,7 @@ def test_torch_tensor_equality_comparator_equal_false(
 ) -> None:
     comparator = TorchTensorEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -545,7 +545,7 @@ def test_torch_tensor_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = TorchTensorEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -605,7 +605,7 @@ def test_torch_tensor_equality_comparator_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert TorchTensorEqualityComparator().equal(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 

--- a/tests/unit/equality/comparators/test_xarray.py
+++ b/tests/unit/equality/comparators/test_xarray.py
@@ -36,50 +36,50 @@ def config() -> EqualityConfig:
 XARRAY_DATA_ARRAY_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.arange(6)),
-            object2=xr.DataArray(np.arange(6)),
+            actual=xr.DataArray(np.arange(6)),
+            expected=xr.DataArray(np.arange(6)),
         ),
         id="1d without dims",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.arange(6), dims=["z"]),
-            object2=xr.DataArray(np.arange(6), dims=["z"]),
+            actual=xr.DataArray(np.arange(6), dims=["z"]),
+            expected=xr.DataArray(np.arange(6), dims=["z"]),
         ),
         id="1d with dims",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.ones((2, 3))),
-            object2=xr.DataArray(np.ones((2, 3))),
+            actual=xr.DataArray(np.ones((2, 3))),
+            expected=xr.DataArray(np.ones((2, 3))),
         ),
         id="2d without dims",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.ones((2, 3)), dims=["x", "y"]),
-            object2=xr.DataArray(np.ones((2, 3)), dims=["x", "y"]),
+            actual=xr.DataArray(np.ones((2, 3)), dims=["x", "y"]),
+            expected=xr.DataArray(np.ones((2, 3)), dims=["x", "y"]),
         ),
         id="2d with dims",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.arange(6)),
-            object2=xr.DataArray(np.arange(6)),
+            actual=xr.DataArray(np.arange(6)),
+            expected=xr.DataArray(np.arange(6)),
         ),
         id="int dtype",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.arange(6, dtype=float)),
-            object2=xr.DataArray(np.arange(6, dtype=float)),
+            actual=xr.DataArray(np.arange(6, dtype=float)),
+            expected=xr.DataArray(np.arange(6, dtype=float)),
         ),
         id="float dtype",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.arange(6), dims=["x"], coords={"x": np.arange(6)}),
-            object2=xr.DataArray(np.arange(6), dims=["x"], coords={"x": np.arange(6)}),
+            actual=xr.DataArray(np.arange(6), dims=["x"], coords={"x": np.arange(6)}),
+            expected=xr.DataArray(np.arange(6), dims=["x"], coords={"x": np.arange(6)}),
         ),
         id="dims and coords",
     ),
@@ -87,48 +87,48 @@ XARRAY_DATA_ARRAY_EQUAL = [
 XARRAY_DATA_ARRAY_NOT_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.ones(6)),
-            object2=xr.DataArray(np.zeros(6)),
+            actual=xr.DataArray(np.ones(6)),
+            expected=xr.DataArray(np.zeros(6)),
             expected_message="objects have different variable:",
         ),
         id="different value",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.arange(6), dims=["z1"]),
-            object2=xr.DataArray(np.arange(6), dims=["z2"]),
+            actual=xr.DataArray(np.arange(6), dims=["z1"]),
+            expected=xr.DataArray(np.arange(6), dims=["z2"]),
             expected_message="objects have different variable:",
         ),
         id="different dims",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.arange(6), name="meow"),
-            object2=xr.DataArray(np.arange(6), name="bear"),
+            actual=xr.DataArray(np.arange(6), name="meow"),
+            expected=xr.DataArray(np.arange(6), name="bear"),
             expected_message="objects have different name:",
         ),
         id="different name",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.arange(6), attrs={"global": "meow"}),
-            object2=xr.DataArray(np.arange(6), attrs={"global": "meoowww"}),
+            actual=xr.DataArray(np.arange(6), attrs={"global": "meow"}),
+            expected=xr.DataArray(np.arange(6), attrs={"global": "meoowww"}),
             expected_message="objects have different variable:",
         ),
         id="different attrs",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.arange(6), coords={"z": [1, 2, 3, 4, 5, 6]}),
-            object2=xr.DataArray(np.arange(6), coords={"z": [10, 20, 30, 40, 50, 60]}),
+            actual=xr.DataArray(np.arange(6), coords={"z": [1, 2, 3, 4, 5, 6]}),
+            expected=xr.DataArray(np.arange(6), coords={"z": [10, 20, 30, 40, 50, 60]}),
             expected_message="objects have different _coords:",
         ),
         id="different coords",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.arange(6)),
-            object2=np.arange(6),
+            actual=xr.DataArray(np.arange(6)),
+            expected=np.arange(6),
             expected_message="objects have different types:",
         ),
         id="different types",
@@ -138,24 +138,24 @@ XARRAY_DATA_ARRAY_EQUAL_TOLERANCE = [
     # atol
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.ones((2, 3))),
-            object2=xr.DataArray(np.full(shape=(2, 3), fill_value=1.5)),
+            actual=xr.DataArray(np.ones((2, 3))),
+            expected=xr.DataArray(np.full(shape=(2, 3), fill_value=1.5)),
             atol=1.0,
         ),
         id="atol=1",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.ones((2, 3))),
-            object2=xr.DataArray(np.full(shape=(2, 3), fill_value=1.05)),
+            actual=xr.DataArray(np.ones((2, 3))),
+            expected=xr.DataArray(np.full(shape=(2, 3), fill_value=1.05)),
             atol=0.1,
         ),
         id="atol=0.1",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.ones((2, 3))),
-            object2=xr.DataArray(np.full(shape=(2, 3), fill_value=1.005)),
+            actual=xr.DataArray(np.ones((2, 3))),
+            expected=xr.DataArray(np.full(shape=(2, 3), fill_value=1.005)),
             atol=0.01,
         ),
         id="atol=0.01",
@@ -163,24 +163,24 @@ XARRAY_DATA_ARRAY_EQUAL_TOLERANCE = [
     # rtol
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.ones((2, 3))),
-            object2=xr.DataArray(np.full(shape=(2, 3), fill_value=1.5)),
+            actual=xr.DataArray(np.ones((2, 3))),
+            expected=xr.DataArray(np.full(shape=(2, 3), fill_value=1.5)),
             rtol=1.0,
         ),
         id="rtol=1",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.ones((2, 3))),
-            object2=xr.DataArray(np.full(shape=(2, 3), fill_value=1.05)),
+            actual=xr.DataArray(np.ones((2, 3))),
+            expected=xr.DataArray(np.full(shape=(2, 3), fill_value=1.05)),
             rtol=0.1,
         ),
         id="rtol=0.1",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.DataArray(np.ones((2, 3))),
-            object2=xr.DataArray(np.full(shape=(2, 3), fill_value=1.005)),
+            actual=xr.DataArray(np.ones((2, 3))),
+            expected=xr.DataArray(np.full(shape=(2, 3), fill_value=1.005)),
             rtol=0.01,
         ),
         id="rtol=0.01",
@@ -190,33 +190,33 @@ XARRAY_DATA_ARRAY_EQUAL_TOLERANCE = [
 XARRAY_DATASET_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=xr.Dataset(data_vars={"x": xr.DataArray(np.arange(6))}),
-            object2=xr.Dataset(data_vars={"x": xr.DataArray(np.arange(6))}),
+            actual=xr.Dataset(data_vars={"x": xr.DataArray(np.arange(6))}),
+            expected=xr.Dataset(data_vars={"x": xr.DataArray(np.arange(6))}),
         ),
         id="data_vars",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.Dataset(coords={"z": np.arange(6)}),
-            object2=xr.Dataset(coords={"z": np.arange(6)}),
+            actual=xr.Dataset(coords={"z": np.arange(6)}),
+            expected=xr.Dataset(coords={"z": np.arange(6)}),
         ),
         id="coords",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.Dataset(attrs={"global": "meow"}),
-            object2=xr.Dataset(attrs={"global": "meow"}),
+            actual=xr.Dataset(attrs={"global": "meow"}),
+            expected=xr.Dataset(attrs={"global": "meow"}),
         ),
         id="attrs",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.Dataset(
+            actual=xr.Dataset(
                 data_vars={"x": xr.DataArray(np.arange(6))},
                 coords={"z": np.arange(6)},
                 attrs={"global": "meow"},
             ),
-            object2=xr.Dataset(
+            expected=xr.Dataset(
                 data_vars={"x": xr.DataArray(np.arange(6))},
                 coords={"z": np.arange(6)},
                 attrs={"global": "meow"},
@@ -228,32 +228,32 @@ XARRAY_DATASET_EQUAL = [
 XARRAY_DATASET_NOT_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=xr.Dataset(data_vars={"x": xr.DataArray(np.zeros(6))}),
-            object2=xr.Dataset(data_vars={"x": xr.DataArray(np.ones(6))}),
+            actual=xr.Dataset(data_vars={"x": xr.DataArray(np.zeros(6))}),
+            expected=xr.Dataset(data_vars={"x": xr.DataArray(np.ones(6))}),
             expected_message="objects have different data_vars:",
         ),
         id="different data_vars",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.Dataset(coords={"z": [1, 2, 3]}),
-            object2=xr.Dataset(coords={"z": [0, 1, 2]}),
+            actual=xr.Dataset(coords={"z": [1, 2, 3]}),
+            expected=xr.Dataset(coords={"z": [0, 1, 2]}),
             expected_message="objects have different coords:",
         ),
         id="different coords",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.Dataset(attrs={"global": "meow"}),
-            object2=xr.Dataset(attrs={"global": "meowwww"}),
+            actual=xr.Dataset(attrs={"global": "meow"}),
+            expected=xr.Dataset(attrs={"global": "meowwww"}),
             expected_message="objects have different attrs:",
         ),
         id="different attrs",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.Dataset(data_vars={"x": xr.DataArray(np.arange(6), dims=["z"])}),
-            object2=np.ones((2, 3)),
+            actual=xr.Dataset(data_vars={"x": xr.DataArray(np.arange(6), dims=["z"])}),
+            expected=np.ones((2, 3)),
             expected_message="objects have different types:",
         ),
         id="different types",
@@ -263,8 +263,8 @@ XARRAY_DATASET_EQUAL_TOLERANCE = [
     # atol
     pytest.param(
         ExamplePair(
-            object1=xr.Dataset(data_vars={"x": xr.DataArray(np.ones((2, 3)))}),
-            object2=xr.Dataset(
+            actual=xr.Dataset(data_vars={"x": xr.DataArray(np.ones((2, 3)))}),
+            expected=xr.Dataset(
                 data_vars={"x": xr.DataArray(np.full(shape=(2, 3), fill_value=1.5))}
             ),
             atol=1.0,
@@ -273,8 +273,8 @@ XARRAY_DATASET_EQUAL_TOLERANCE = [
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.Dataset(data_vars={"x": xr.DataArray(np.ones((2, 3)))}),
-            object2=xr.Dataset(
+            actual=xr.Dataset(data_vars={"x": xr.DataArray(np.ones((2, 3)))}),
+            expected=xr.Dataset(
                 data_vars={"x": xr.DataArray(np.full(shape=(2, 3), fill_value=1.05))}
             ),
             atol=0.1,
@@ -283,8 +283,8 @@ XARRAY_DATASET_EQUAL_TOLERANCE = [
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.Dataset(data_vars={"x": xr.DataArray(np.ones((2, 3)))}),
-            object2=xr.Dataset(
+            actual=xr.Dataset(data_vars={"x": xr.DataArray(np.ones((2, 3)))}),
+            expected=xr.Dataset(
                 data_vars={"x": xr.DataArray(np.full(shape=(2, 3), fill_value=1.005))}
             ),
             atol=0.1,
@@ -294,8 +294,8 @@ XARRAY_DATASET_EQUAL_TOLERANCE = [
     # rtol
     pytest.param(
         ExamplePair(
-            object1=xr.Dataset(data_vars={"x": xr.DataArray(np.ones((2, 3)))}),
-            object2=xr.Dataset(
+            actual=xr.Dataset(data_vars={"x": xr.DataArray(np.ones((2, 3)))}),
+            expected=xr.Dataset(
                 data_vars={"x": xr.DataArray(np.full(shape=(2, 3), fill_value=1.5))}
             ),
             rtol=1.0,
@@ -304,8 +304,8 @@ XARRAY_DATASET_EQUAL_TOLERANCE = [
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.Dataset(data_vars={"x": xr.DataArray(np.ones((2, 3)))}),
-            object2=xr.Dataset(
+            actual=xr.Dataset(data_vars={"x": xr.DataArray(np.ones((2, 3)))}),
+            expected=xr.Dataset(
                 data_vars={"x": xr.DataArray(np.full(shape=(2, 3), fill_value=1.05))}
             ),
             rtol=0.1,
@@ -314,8 +314,8 @@ XARRAY_DATASET_EQUAL_TOLERANCE = [
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.Dataset(data_vars={"x": xr.DataArray(np.ones((2, 3)))}),
-            object2=xr.Dataset(
+            actual=xr.Dataset(data_vars={"x": xr.DataArray(np.ones((2, 3)))}),
+            expected=xr.Dataset(
                 data_vars={"x": xr.DataArray(np.full(shape=(2, 3), fill_value=1.005))}
             ),
             rtol=0.1,
@@ -327,15 +327,15 @@ XARRAY_DATASET_EQUAL_TOLERANCE = [
 XARRAY_VARIABLE_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=xr.Variable(dims=["z"], data=np.arange(6)),
-            object2=xr.Variable(dims=["z"], data=np.arange(6)),
+            actual=xr.Variable(dims=["z"], data=np.arange(6)),
+            expected=xr.Variable(dims=["z"], data=np.arange(6)),
         ),
         id="1d",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.Variable(dims=["x", "y"], data=np.ones((2, 3))),
-            object2=xr.Variable(dims=["x", "y"], data=np.ones((2, 3))),
+            actual=xr.Variable(dims=["x", "y"], data=np.ones((2, 3))),
+            expected=xr.Variable(dims=["x", "y"], data=np.ones((2, 3))),
         ),
         id="2d",
     ),
@@ -343,32 +343,32 @@ XARRAY_VARIABLE_EQUAL = [
 XARRAY_VARIABLE_NOT_EQUAL = [
     pytest.param(
         ExamplePair(
-            object1=xr.Variable(dims=["z"], data=np.ones(6)),
-            object2=xr.Variable(dims=["z"], data=np.zeros(6)),
+            actual=xr.Variable(dims=["z"], data=np.ones(6)),
+            expected=xr.Variable(dims=["z"], data=np.zeros(6)),
             expected_message="objects have different data:",
         ),
         id="different data",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.Variable(dims=["x"], data=np.arange(6)),
-            object2=xr.Variable(dims=["y"], data=np.arange(6)),
+            actual=xr.Variable(dims=["x"], data=np.arange(6)),
+            expected=xr.Variable(dims=["y"], data=np.arange(6)),
             expected_message="objects have different dims:",
         ),
         id="different dims",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.Variable(dims=["z"], data=np.arange(6), attrs={"global": "meow"}),
-            object2=xr.Variable(dims=["z"], data=np.arange(6), attrs={"global": "meoowww"}),
+            actual=xr.Variable(dims=["z"], data=np.arange(6), attrs={"global": "meow"}),
+            expected=xr.Variable(dims=["z"], data=np.arange(6), attrs={"global": "meoowww"}),
             expected_message="objects have different attrs:",
         ),
         id="different attrs",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.Variable(dims=["z"], data=np.ones(6)),
-            object2=np.ones(6),
+            actual=xr.Variable(dims=["z"], data=np.ones(6)),
+            expected=np.ones(6),
             expected_message="objects have different types:",
         ),
         id="different types",
@@ -378,24 +378,24 @@ XARRAY_VARIABLE_EQUAL_TOLERANCE = [
     # atol
     pytest.param(
         ExamplePair(
-            object1=xr.Variable(dims=["z"], data=np.ones(3)),
-            object2=xr.Variable(dims=["z"], data=np.full(shape=3, fill_value=1.5)),
+            actual=xr.Variable(dims=["z"], data=np.ones(3)),
+            expected=xr.Variable(dims=["z"], data=np.full(shape=3, fill_value=1.5)),
             atol=1.0,
         ),
         id="atol=1",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.Variable(dims=["z"], data=np.ones(3)),
-            object2=xr.Variable(dims=["z"], data=np.full(shape=3, fill_value=1.05)),
+            actual=xr.Variable(dims=["z"], data=np.ones(3)),
+            expected=xr.Variable(dims=["z"], data=np.full(shape=3, fill_value=1.05)),
             atol=0.1,
         ),
         id="atol=0.1",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.Variable(dims=["z"], data=np.ones(3)),
-            object2=xr.Variable(dims=["z"], data=np.full(shape=3, fill_value=1.005)),
+            actual=xr.Variable(dims=["z"], data=np.ones(3)),
+            expected=xr.Variable(dims=["z"], data=np.full(shape=3, fill_value=1.005)),
             atol=0.01,
         ),
         id="atol=0.01",
@@ -403,24 +403,24 @@ XARRAY_VARIABLE_EQUAL_TOLERANCE = [
     # rtol
     pytest.param(
         ExamplePair(
-            object1=xr.Variable(dims=["z"], data=np.ones(3)),
-            object2=xr.Variable(dims=["z"], data=np.full(shape=3, fill_value=1.5)),
+            actual=xr.Variable(dims=["z"], data=np.ones(3)),
+            expected=xr.Variable(dims=["z"], data=np.full(shape=3, fill_value=1.5)),
             rtol=1.0,
         ),
         id="rtol=1",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.Variable(dims=["z"], data=np.ones(3)),
-            object2=xr.Variable(dims=["z"], data=np.full(shape=3, fill_value=1.05)),
+            actual=xr.Variable(dims=["z"], data=np.ones(3)),
+            expected=xr.Variable(dims=["z"], data=np.full(shape=3, fill_value=1.05)),
             rtol=0.1,
         ),
         id="rtol=0.1",
     ),
     pytest.param(
         ExamplePair(
-            object1=xr.Variable(dims=["z"], data=np.ones(3)),
-            object2=xr.Variable(dims=["z"], data=np.full(shape=3, fill_value=1.005)),
+            actual=xr.Variable(dims=["z"], data=np.ones(3)),
+            expected=xr.Variable(dims=["z"], data=np.full(shape=3, fill_value=1.005)),
             rtol=0.01,
         ),
         id="rtol=0.01",
@@ -483,7 +483,7 @@ def test_xarray_data_array_equality_comparator_equal_yes(
 ) -> None:
     comparator = XarrayDataArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -497,7 +497,7 @@ def test_xarray_data_array_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = XarrayDataArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -510,7 +510,7 @@ def test_xarray_data_array_equality_comparator_equal_false(
 ) -> None:
     comparator = XarrayDataArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -524,7 +524,7 @@ def test_xarray_data_array_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = XarrayDataArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -552,7 +552,7 @@ def test_xarray_data_array_equality_comparator_equal_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert XarrayDataArrayEqualityComparator().equal(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 
@@ -632,7 +632,7 @@ def test_xarray_dataset_equality_comparator_equal_yes(
 ) -> None:
     comparator = XarrayDatasetEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -646,7 +646,7 @@ def test_xarray_dataset_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = XarrayDatasetEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -659,7 +659,7 @@ def test_xarray_dataset_equality_comparator_equal_false(
 ) -> None:
     comparator = XarrayDatasetEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -673,7 +673,7 @@ def test_xarray_dataset_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = XarrayDatasetEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -701,7 +701,7 @@ def test_xarray_dataset_equality_comparator_equal_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert XarrayDatasetEqualityComparator().equal(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 
@@ -757,7 +757,7 @@ def test_xarray_variable_equality_comparator_equal_yes(
 ) -> None:
     comparator = XarrayVariableEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -771,7 +771,7 @@ def test_xarray_variable_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = XarrayVariableEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -784,7 +784,7 @@ def test_xarray_variable_equality_comparator_equal_false(
 ) -> None:
     comparator = XarrayVariableEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert not caplog.messages
 
 
@@ -798,7 +798,7 @@ def test_xarray_variable_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = XarrayVariableEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
+        assert not comparator.equal(actual=example.actual, expected=example.expected, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -826,7 +826,7 @@ def test_xarray_variable_equality_comparator_equal_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert XarrayVariableEqualityComparator().equal(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 

--- a/tests/unit/equality/comparators/test_xarray.py
+++ b/tests/unit/equality/comparators/test_xarray.py
@@ -483,7 +483,7 @@ def test_xarray_data_array_equality_comparator_equal_yes(
 ) -> None:
     comparator = XarrayDataArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -497,7 +497,7 @@ def test_xarray_data_array_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = XarrayDataArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -510,7 +510,7 @@ def test_xarray_data_array_equality_comparator_equal_false(
 ) -> None:
     comparator = XarrayDataArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -524,7 +524,7 @@ def test_xarray_data_array_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = XarrayDataArrayEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -552,7 +552,7 @@ def test_xarray_data_array_equality_comparator_equal_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert XarrayDataArrayEqualityComparator().equal(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 
@@ -632,7 +632,7 @@ def test_xarray_dataset_equality_comparator_equal_yes(
 ) -> None:
     comparator = XarrayDatasetEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -646,7 +646,7 @@ def test_xarray_dataset_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = XarrayDatasetEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -659,7 +659,7 @@ def test_xarray_dataset_equality_comparator_equal_false(
 ) -> None:
     comparator = XarrayDatasetEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -673,7 +673,7 @@ def test_xarray_dataset_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = XarrayDatasetEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -701,7 +701,7 @@ def test_xarray_dataset_equality_comparator_equal_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert XarrayDatasetEqualityComparator().equal(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 
@@ -757,7 +757,7 @@ def test_xarray_variable_equality_comparator_equal_yes(
 ) -> None:
     comparator = XarrayVariableEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -771,7 +771,7 @@ def test_xarray_variable_equality_comparator_equal_yes_show_difference(
     config.show_difference = True
     comparator = XarrayVariableEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -784,7 +784,7 @@ def test_xarray_variable_equality_comparator_equal_false(
 ) -> None:
     comparator = XarrayVariableEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert not caplog.messages
 
 
@@ -798,7 +798,7 @@ def test_xarray_variable_equality_comparator_equal_false_show_difference(
     config.show_difference = True
     comparator = XarrayVariableEqualityComparator()
     with caplog.at_level(logging.INFO):
-        assert not comparator.equal(object1=example.object1, object2=example.object2, config=config)
+        assert not comparator.equal(actual=example.object1, expected=example.object2, config=config)
         assert caplog.messages[-1].startswith(example.expected_message)
 
 
@@ -826,7 +826,7 @@ def test_xarray_variable_equality_comparator_equal_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert XarrayVariableEqualityComparator().equal(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 

--- a/tests/unit/equality/comparators/utils.py
+++ b/tests/unit/equality/comparators/utils.py
@@ -10,8 +10,8 @@ from typing import Any
 
 @dataclass
 class ExamplePair:
-    object1: Any
-    object2: Any
+    actual: Any
+    expected: Any
     expected_message: str | None = None
     atol: float = 0.0
     rtol: float = 0.0

--- a/tests/unit/equality/handlers/test_base.py
+++ b/tests/unit/equality/handlers/test_base.py
@@ -21,11 +21,11 @@ def test_chain_1(config: EqualityConfig) -> None:
     handler = SameObjectHandler()
     handler.chain(TrueHandler())
     assert handler.next_handler == TrueHandler()
-    assert handler.handle(object1=[1, 2, 3], object2=[1, 2, 3], config=config)
+    assert handler.handle(actual=[1, 2, 3], expected=[1, 2, 3], config=config)
 
 
 def test_chain_multiple(config: EqualityConfig) -> None:
     handler = SameObjectHandler()
     handler.chain(SameTypeHandler()).chain(ObjectEqualHandler())
     assert handler.next_handler == SameTypeHandler()
-    assert handler.handle(object1=[1, 2, 3], object2=[1, 2, 3], config=config)
+    assert handler.handle(actual=[1, 2, 3], expected=[1, 2, 3], config=config)

--- a/tests/unit/equality/handlers/test_data.py
+++ b/tests/unit/equality/handlers/test_data.py
@@ -48,7 +48,7 @@ def test_same_data_handler_str() -> None:
 
 @numpy_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (np.ones(shape=(2, 3)), np.ones(shape=(2, 3))),
         (np.zeros(shape=(2, 3)), np.zeros(shape=(2, 3))),
@@ -57,14 +57,14 @@ def test_same_data_handler_str() -> None:
     ],
 )
 def test_same_data_handler_handle_true(
-    object1: np.ndarray, object2: np.ndarray, config: EqualityConfig
+    actual: np.ndarray, expected: np.ndarray, config: EqualityConfig
 ) -> None:
-    assert SameDataHandler(next_handler=TrueHandler()).handle(object1, object2, config)
+    assert SameDataHandler(next_handler=TrueHandler()).handle(actual, expected, config)
 
 
 @numpy_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (np.ones(shape=(2, 3)), np.zeros(shape=(2, 3))),
         (np.ones(shape=(2, 3)), np.ones(shape=(2, 3, 1))),
@@ -72,9 +72,9 @@ def test_same_data_handler_handle_true(
     ],
 )
 def test_same_data_handler_handle_false(
-    object1: np.ndarray, object2: np.ndarray, config: EqualityConfig
+    actual: np.ndarray, expected: np.ndarray, config: EqualityConfig
 ) -> None:
-    assert not SameDataHandler().handle(object1, object2, config)
+    assert not SameDataHandler().handle(actual, expected, config)
 
 
 @numpy_available

--- a/tests/unit/equality/handlers/test_data.py
+++ b/tests/unit/equality/handlers/test_data.py
@@ -85,7 +85,7 @@ def test_same_data_handler_handle_false_show_difference(
     handler = SameDataHandler()
     with caplog.at_level(logging.INFO):
         assert not handler.handle(
-            object1=np.ones(shape=(2, 3)), object2=np.zeros(shape=(2, 3)), config=config
+            actual=np.ones(shape=(2, 3)), expected=np.zeros(shape=(2, 3)), config=config
         )
         assert caplog.messages[-1].startswith("objects have different data:")
 
@@ -94,7 +94,7 @@ def test_same_data_handler_handle_false_show_difference(
 def test_same_data_handler_handle_without_next_handler(config: EqualityConfig) -> None:
     handler = SameDataHandler()
     with pytest.raises(RuntimeError, match="next handler is not defined"):
-        handler.handle(object1=np.ones(shape=(2, 3)), object2=np.ones(shape=(2, 3)), config=config)
+        handler.handle(actual=np.ones(shape=(2, 3)), expected=np.ones(shape=(2, 3)), config=config)
 
 
 def test_same_data_handler_set_next_handler() -> None:

--- a/tests/unit/equality/handlers/test_dtype.py
+++ b/tests/unit/equality/handlers/test_dtype.py
@@ -86,8 +86,8 @@ def test_same_dtype_handler_handle_false_show_difference(
     handler = SameDTypeHandler()
     with caplog.at_level(logging.INFO):
         assert not handler.handle(
-            object1=np.ones(shape=(2, 3), dtype=float),
-            object2=np.ones(shape=(2, 3), dtype=int),
+            actual=np.ones(shape=(2, 3), dtype=float),
+            expected=np.ones(shape=(2, 3), dtype=int),
             config=config,
         )
         assert caplog.messages[0].startswith("objects have different data types:")
@@ -97,7 +97,7 @@ def test_same_dtype_handler_handle_false_show_difference(
 def test_same_dtype_handler_handle_without_next_handler(config: EqualityConfig) -> None:
     handler = SameDTypeHandler()
     with pytest.raises(RuntimeError, match="next handler is not defined"):
-        handler.handle(object1=np.ones(shape=(2, 3)), object2=np.ones(shape=(2, 3)), config=config)
+        handler.handle(actual=np.ones(shape=(2, 3)), expected=np.ones(shape=(2, 3)), config=config)
 
 
 def test_same_dtype_handler_set_next_handler() -> None:

--- a/tests/unit/equality/handlers/test_dtype.py
+++ b/tests/unit/equality/handlers/test_dtype.py
@@ -50,7 +50,7 @@ def test_same_dtype_handler_str() -> None:
 
 @numpy_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (np.ones(shape=(2, 3), dtype=float), np.zeros(shape=(2, 3), dtype=float)),
         (np.ones(shape=(2, 3), dtype=int), np.zeros(shape=(2, 3), dtype=int)),
@@ -58,14 +58,14 @@ def test_same_dtype_handler_str() -> None:
     ],
 )
 def test_same_dtype_handler_handle_true(
-    object1: np.ndarray, object2: np.ndarray, config: EqualityConfig
+    actual: np.ndarray, expected: np.ndarray, config: EqualityConfig
 ) -> None:
-    assert SameDTypeHandler(next_handler=TrueHandler()).handle(object1, object2, config)
+    assert SameDTypeHandler(next_handler=TrueHandler()).handle(actual, expected, config)
 
 
 @numpy_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (np.ones(shape=(2, 3), dtype=float), np.ones(shape=(2, 3), dtype=int)),
         (np.ones(shape=(2, 3), dtype=int), np.ones(shape=(2, 3), dtype=bool)),
@@ -73,9 +73,9 @@ def test_same_dtype_handler_handle_true(
     ],
 )
 def test_same_dtype_handler_handle_false(
-    object1: np.ndarray, object2: np.ndarray, config: EqualityConfig
+    actual: np.ndarray, expected: np.ndarray, config: EqualityConfig
 ) -> None:
-    assert not SameDTypeHandler().handle(object1, object2, config)
+    assert not SameDTypeHandler().handle(actual, expected, config)
 
 
 @numpy_available

--- a/tests/unit/equality/handlers/test_equal.py
+++ b/tests/unit/equality/handlers/test_equal.py
@@ -51,17 +51,17 @@ def test_same_data_handler_str() -> None:
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [(MyFloat(42), 42), (MyFloat(0), 0)],
 )
 def test_equal_handler_handle_true(
-    object1: SupportsEqual, object2: Any, config: EqualityConfig
+    actual: SupportsEqual, expected: Any, config: EqualityConfig
 ) -> None:
-    assert EqualHandler().handle(object1, object2, config)
+    assert EqualHandler().handle(actual, expected, config)
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (MyFloat(42), 1),
         (MyFloat(0), float("nan")),
@@ -69,9 +69,9 @@ def test_equal_handler_handle_true(
     ],
 )
 def test_equal_handler_handle_false(
-    object1: SupportsEqual, object2: Any, config: EqualityConfig
+    actual: SupportsEqual, expected: Any, config: EqualityConfig
 ) -> None:
-    assert not EqualHandler().handle(object1, object2, config)
+    assert not EqualHandler().handle(actual, expected, config)
 
 
 def test_equal_handler_handle_false_show_difference(

--- a/tests/unit/equality/handlers/test_equal.py
+++ b/tests/unit/equality/handlers/test_equal.py
@@ -80,7 +80,7 @@ def test_equal_handler_handle_false_show_difference(
     config.show_difference = True
     handler = EqualHandler()
     with caplog.at_level(logging.INFO):
-        assert not handler.handle(object1=MyFloat(42), object2=1, config=config)
+        assert not handler.handle(actual=MyFloat(42), expected=1, config=config)
         assert caplog.messages[-1].startswith("objects are not equal:")
 
 

--- a/tests/unit/equality/handlers/test_jax.py
+++ b/tests/unit/equality/handlers/test_jax.py
@@ -102,7 +102,7 @@ def test_jax_array_equal_handler_handle_false_show_difference(
     handler = JaxArrayEqualHandler()
     with caplog.at_level(logging.INFO):
         assert not handler.handle(
-            object1=jnp.ones(shape=(2, 3)), object2=jnp.ones(shape=(3, 2)), config=config
+            actual=jnp.ones(shape=(2, 3)), expected=jnp.ones(shape=(3, 2)), config=config
         )
         assert caplog.messages[0].startswith("jax.numpy.ndarrays have different elements:")
 
@@ -115,7 +115,7 @@ def test_jax_array_equal_handler_handle_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert JaxArrayEqualHandler().handle(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 

--- a/tests/unit/equality/handlers/test_jax.py
+++ b/tests/unit/equality/handlers/test_jax.py
@@ -51,7 +51,7 @@ def test_jax_array_equal_handler_str() -> None:
 
 @jax_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (jnp.ones(shape=(2, 3), dtype=float), jnp.ones(shape=(2, 3), dtype=float)),
         (jnp.ones(shape=(2, 3), dtype=int), jnp.ones(shape=(2, 3), dtype=int)),
@@ -59,14 +59,14 @@ def test_jax_array_equal_handler_str() -> None:
     ],
 )
 def test_jax_array_equal_handler_handle_true(
-    object1: jnp.ndarray, object2: jnp.ndarray, config: EqualityConfig
+    actual: jnp.ndarray, expected: jnp.ndarray, config: EqualityConfig
 ) -> None:
-    assert JaxArrayEqualHandler().handle(object1, object2, config)
+    assert JaxArrayEqualHandler().handle(actual, expected, config)
 
 
 @jax_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (jnp.ones(shape=(2, 3)), jnp.ones(shape=(3, 2))),
         (jnp.ones(shape=(2, 3)), jnp.ones(shape=(2, 1))),
@@ -74,9 +74,9 @@ def test_jax_array_equal_handler_handle_true(
     ],
 )
 def test_jax_array_equal_handler_handle_false(
-    object1: jnp.ndarray, object2: jnp.ndarray, config: EqualityConfig
+    actual: jnp.ndarray, expected: jnp.ndarray, config: EqualityConfig
 ) -> None:
-    assert not JaxArrayEqualHandler().handle(object1, object2, config)
+    assert not JaxArrayEqualHandler().handle(actual, expected, config)
 
 
 @jax_available
@@ -115,7 +115,7 @@ def test_jax_array_equal_handler_handle_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert JaxArrayEqualHandler().handle(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 

--- a/tests/unit/equality/handlers/test_mapping.py
+++ b/tests/unit/equality/handlers/test_mapping.py
@@ -45,29 +45,29 @@ def test_mapping_same_keys_handler_str() -> None:
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ({}, {}),
         ({"a": 1, "b": 2}, {"a": 1, "b": 2}),
     ],
 )
 def test_mapping_same_keys_handler_handle_true(
-    object1: Mapping, object2: Mapping, config: EqualityConfig
+    actual: Mapping, expected: Mapping, config: EqualityConfig
 ) -> None:
-    assert MappingSameKeysHandler(next_handler=TrueHandler()).handle(object1, object2, config)
+    assert MappingSameKeysHandler(next_handler=TrueHandler()).handle(actual, expected, config)
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ({"a": 1, "b": 2}, {}),
         ({"a": 1, "b": 2}, {"a": 1, "b": 2, "c": 1}),
     ],
 )
 def test_mapping_same_keys_handler_handle_false(
-    object1: Mapping, object2: Mapping, config: EqualityConfig
+    actual: Mapping, expected: Mapping, config: EqualityConfig
 ) -> None:
-    assert not MappingSameKeysHandler().handle(object1, object2, config)
+    assert not MappingSameKeysHandler().handle(actual, expected, config)
 
 
 def test_mapping_same_keys_handler_handle_false_show_difference(
@@ -122,7 +122,7 @@ def test_mapping_same_values_handler_str() -> None:
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ({}, {}),
         ({}, {"a": 1, "b": 2}),
@@ -132,22 +132,22 @@ def test_mapping_same_values_handler_str() -> None:
     ],
 )
 def test_mapping_same_values_handler_handle_true(
-    object1: Mapping, object2: Mapping, config: EqualityConfig
+    actual: Mapping, expected: Mapping, config: EqualityConfig
 ) -> None:
-    assert MappingSameValuesHandler(next_handler=TrueHandler()).handle(object1, object2, config)
+    assert MappingSameValuesHandler(next_handler=TrueHandler()).handle(actual, expected, config)
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ({"a": 1, "b": 2}, {"a": 1, "b": 3}),
         ({"a": 1, "b": {"k": 1}}, {"a": 1, "b": {"k": 2}}),
     ],
 )
 def test_mapping_same_values_handler_handle_false(
-    object1: Mapping, object2: Mapping, config: EqualityConfig
+    actual: Mapping, expected: Mapping, config: EqualityConfig
 ) -> None:
-    assert not MappingSameValuesHandler().handle(object1, object2, config)
+    assert not MappingSameValuesHandler().handle(actual, expected, config)
 
 
 def test_mapping_same_values_handler_handle_false_show_difference(

--- a/tests/unit/equality/handlers/test_mapping.py
+++ b/tests/unit/equality/handlers/test_mapping.py
@@ -77,7 +77,7 @@ def test_mapping_same_keys_handler_handle_false_show_difference(
     handler = MappingSameKeysHandler()
     with caplog.at_level(logging.INFO):
         assert not handler.handle(
-            object1={"a": 1, "b": 2}, object2={"a": 1, "b": 2, "c": 1}, config=config
+            actual={"a": 1, "b": 2}, expected={"a": 1, "b": 2, "c": 1}, config=config
         )
         assert caplog.messages[0].startswith("mappings have different keys:")
 
@@ -85,7 +85,7 @@ def test_mapping_same_keys_handler_handle_false_show_difference(
 def test_mapping_same_keys_handler_handle_without_next_handler(config: EqualityConfig) -> None:
     handler = MappingSameKeysHandler()
     with pytest.raises(RuntimeError, match="next handler is not defined"):
-        handler.handle(object1={"a": 1, "b": 2}, object2={"a": 1, "b": 2}, config=config)
+        handler.handle(actual={"a": 1, "b": 2}, expected={"a": 1, "b": 2}, config=config)
 
 
 def test_mapping_same_keys_handler_set_next_handler() -> None:
@@ -156,14 +156,14 @@ def test_mapping_same_values_handler_handle_false_show_difference(
     config.show_difference = True
     handler = MappingSameValuesHandler()
     with caplog.at_level(logging.INFO):
-        assert not handler.handle(object1={"a": 1, "b": 2}, object2={"a": 1, "b": 3}, config=config)
+        assert not handler.handle(actual={"a": 1, "b": 2}, expected={"a": 1, "b": 3}, config=config)
         assert caplog.messages[-1].startswith("mappings have at least one different value:")
 
 
 def test_mapping_same_values_handler_handle_without_next_handler(config: EqualityConfig) -> None:
     handler = MappingSameValuesHandler()
     with pytest.raises(RuntimeError, match="next handler is not defined"):
-        handler.handle(object1={"a": 1, "b": 2}, object2={"a": 1, "b": 2}, config=config)
+        handler.handle(actual={"a": 1, "b": 2}, expected={"a": 1, "b": 2}, config=config)
 
 
 def test_mapping_same_values_handler_set_next_handler() -> None:

--- a/tests/unit/equality/handlers/test_native.py
+++ b/tests/unit/equality/handlers/test_native.py
@@ -56,10 +56,10 @@ def test_false_handler_str() -> None:
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"), [(0, 0), (4.2, 4.2), ("abc", "abc"), (0, 1), (4, 4.0), ("abc", "ABC")]
+    ("actual", "expected"), [(0, 0), (4.2, 4.2), ("abc", "abc"), (0, 1), (4, 4.0), ("abc", "ABC")]
 )
-def test_false_handler_handle(object1: Any, object2: Any, config: EqualityConfig) -> None:
-    assert not FalseHandler().handle(object1, object2, config)
+def test_false_handler_handle(actual: Any, expected: Any, config: EqualityConfig) -> None:
+    assert not FalseHandler().handle(actual, expected, config)
 
 
 def test_false_handler_set_next_handler() -> None:
@@ -88,10 +88,10 @@ def test_true_handler_str() -> None:
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"), [(0, 0), (4.2, 4.2), ("abc", "abc"), (0, 1), (4, 4.0), ("abc", "ABC")]
+    ("actual", "expected"), [(0, 0), (4.2, 4.2), ("abc", "abc"), (0, 1), (4, 4.0), ("abc", "ABC")]
 )
-def test_true_handler_handle(object1: Any, object2: Any, config: EqualityConfig) -> None:
-    assert TrueHandler().handle(object1, object2, config)
+def test_true_handler_handle(actual: Any, expected: Any, config: EqualityConfig) -> None:
+    assert TrueHandler().handle(actual, expected, config)
 
 
 def test_true_handler_set_next_handler() -> None:
@@ -119,18 +119,18 @@ def test_object_equal_handler_str() -> None:
     assert str(ObjectEqualHandler()) == "ObjectEqualHandler()"
 
 
-@pytest.mark.parametrize(("object1", "object2"), [(0, 0), (4.2, 4.2), ("abc", "abc")])
+@pytest.mark.parametrize(("actual", "expected"), [(0, 0), (4.2, 4.2), ("abc", "abc")])
 def test_object_equal_handler_handle_true(
-    object1: Any, object2: Any, config: EqualityConfig
+    actual: Any, expected: Any, config: EqualityConfig
 ) -> None:
-    assert ObjectEqualHandler().handle(object1, object2, config)
+    assert ObjectEqualHandler().handle(actual, expected, config)
 
 
-@pytest.mark.parametrize(("object1", "object2"), [(0, 1), (4, 4.2), ("abc", "ABC")])
+@pytest.mark.parametrize(("actual", "expected"), [(0, 1), (4, 4.2), ("abc", "ABC")])
 def test_object_equal_handler_handle_false(
-    object1: Any, object2: Any, config: EqualityConfig
+    actual: Any, expected: Any, config: EqualityConfig
 ) -> None:
-    assert not ObjectEqualHandler().handle(object1, object2, config)
+    assert not ObjectEqualHandler().handle(actual, expected, config)
 
 
 def test_object_equal_handler_handle_false_show_difference(
@@ -173,7 +173,7 @@ def test_same_attribute_handler_str() -> None:
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (Mock(data=1), Mock(data=1)),
         (Mock(data="abc"), Mock(data="abc")),
@@ -181,15 +181,15 @@ def test_same_attribute_handler_str() -> None:
     ],
 )
 def test_same_attribute_handler_handle_true(
-    object1: Any, object2: Any, config: EqualityConfig
+    actual: Any, expected: Any, config: EqualityConfig
 ) -> None:
     assert SameAttributeHandler(name="data", next_handler=TrueHandler()).handle(
-        object1, object2, config
+        actual, expected, config
     )
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (Mock(data=1), Mock(data=2)),
         (Mock(data="abc"), Mock(data="abcd")),
@@ -197,9 +197,9 @@ def test_same_attribute_handler_handle_true(
     ],
 )
 def test_same_attribute_handler_handle_false(
-    object1: Any, object2: Any, config: EqualityConfig
+    actual: Any, expected: Any, config: EqualityConfig
 ) -> None:
-    assert not SameAttributeHandler(name="data").handle(object1, object2, config)
+    assert not SameAttributeHandler(name="data").handle(actual, expected, config)
 
 
 @numpy_available
@@ -274,7 +274,7 @@ def test_same_length_handler_str() -> None:
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ([], []),
         ([1, 2, 3], [4, 5, 6]),
@@ -285,13 +285,13 @@ def test_same_length_handler_str() -> None:
     ],
 )
 def test_same_length_handler_handle_true(
-    object1: Sized, object2: Sized, config: EqualityConfig
+    actual: Sized, expected: Sized, config: EqualityConfig
 ) -> None:
-    assert SameLengthHandler(next_handler=TrueHandler()).handle(object1, object2, config)
+    assert SameLengthHandler(next_handler=TrueHandler()).handle(actual, expected, config)
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ([1, 2], [1, 2, 3]),
         ((4, 5), (4, 5, None)),
@@ -299,9 +299,9 @@ def test_same_length_handler_handle_true(
     ],
 )
 def test_same_length_handler_handle_false(
-    object1: Sized, object2: Sized, config: EqualityConfig
+    actual: Sized, expected: Sized, config: EqualityConfig
 ) -> None:
-    assert not SameLengthHandler().handle(object1, object2, config)
+    assert not SameLengthHandler().handle(actual, expected, config)
 
 
 def test_same_length_handler_handle_false_show_difference(
@@ -353,18 +353,18 @@ def test_same_object_handler_str() -> None:
     assert str(SameObjectHandler()) == "SameObjectHandler()"
 
 
-@pytest.mark.parametrize(("object1", "object2"), [(0, 0), (4.2, 4.2), ("abc", "abc")])
+@pytest.mark.parametrize(("actual", "expected"), [(0, 0), (4.2, 4.2), ("abc", "abc")])
 def test_same_object_handler_handle_true(
-    object1: Any, object2: Any, config: EqualityConfig
+    actual: Any, expected: Any, config: EqualityConfig
 ) -> None:
-    assert SameObjectHandler().handle(object1, object2, config)
+    assert SameObjectHandler().handle(actual, expected, config)
 
 
-@pytest.mark.parametrize(("object1", "object2"), [(0, 1), (4, 4.0), ("abc", "ABC")])
+@pytest.mark.parametrize(("actual", "expected"), [(0, 1), (4, 4.0), ("abc", "ABC")])
 def test_same_object_handler_handle_false(
-    object1: Any, object2: Any, config: EqualityConfig
+    actual: Any, expected: Any, config: EqualityConfig
 ) -> None:
-    assert not SameObjectHandler(next_handler=FalseHandler()).handle(object1, object2, config)
+    assert not SameObjectHandler(next_handler=FalseHandler()).handle(actual, expected, config)
 
 
 def test_same_object_handler_handle_without_next_handler(config: EqualityConfig) -> None:
@@ -406,14 +406,14 @@ def test_same_type_handler_str() -> None:
     assert str(SameTypeHandler()) == "SameTypeHandler()"
 
 
-@pytest.mark.parametrize(("object1", "object2"), [(0, 0), (4.2, 4.2), ("abc", "abc")])
-def test_same_type_handler_handle_true(object1: Any, object2: Any, config: EqualityConfig) -> None:
-    assert SameTypeHandler(next_handler=TrueHandler()).handle(object1, object2, config)
+@pytest.mark.parametrize(("actual", "expected"), [(0, 0), (4.2, 4.2), ("abc", "abc")])
+def test_same_type_handler_handle_true(actual: Any, expected: Any, config: EqualityConfig) -> None:
+    assert SameTypeHandler(next_handler=TrueHandler()).handle(actual, expected, config)
 
 
-@pytest.mark.parametrize(("object1", "object2"), [(0, "abc"), (4, 4.0), (None, 0)])
-def test_same_type_handler_handle_false(object1: Any, object2: Any, config: EqualityConfig) -> None:
-    assert not SameTypeHandler().handle(object1, object2, config)
+@pytest.mark.parametrize(("actual", "expected"), [(0, "abc"), (4, 4.0), (None, 0)])
+def test_same_type_handler_handle_false(actual: Any, expected: Any, config: EqualityConfig) -> None:
+    assert not SameTypeHandler().handle(actual, expected, config)
 
 
 def test_same_type_handler_handle_false_show_difference(

--- a/tests/unit/equality/handlers/test_native.py
+++ b/tests/unit/equality/handlers/test_native.py
@@ -139,7 +139,7 @@ def test_object_equal_handler_handle_false_show_difference(
     config.show_difference = True
     handler = ObjectEqualHandler()
     with caplog.at_level(logging.INFO):
-        assert not handler.handle(object1=[1, 2, 3], object2=[1, 2, 3, 4], config=config)
+        assert not handler.handle(actual=[1, 2, 3], expected=[1, 2, 3, 4], config=config)
         assert caplog.messages[0].startswith("objects are different:")
 
 
@@ -210,8 +210,8 @@ def test_same_attribute_handler_handle_false_show_difference(
     handler = SameAttributeHandler(name="data")
     with caplog.at_level(logging.INFO):
         assert not handler.handle(
-            object1=Mock(data=1),
-            object2=Mock(data=2),
+            actual=Mock(data=1),
+            expected=Mock(data=2),
             config=config,
         )
         assert caplog.messages[-1].startswith("objects have different data:")
@@ -222,7 +222,7 @@ def test_same_attribute_handler_handle_without_next_handler(config: EqualityConf
     handler = SameAttributeHandler(name="data")
     with pytest.raises(RuntimeError, match="next handler is not defined"):
         handler.handle(
-            object1=Mock(spec=Any, data=1), object2=Mock(spec=Any, data=1), config=config
+            actual=Mock(spec=Any, data=1), expected=Mock(spec=Any, data=1), config=config
         )
 
 
@@ -310,14 +310,14 @@ def test_same_length_handler_handle_false_show_difference(
     config.show_difference = True
     handler = SameLengthHandler()
     with caplog.at_level(logging.INFO):
-        assert not handler.handle(object1=[1, 2, 3], object2=[1, 2, 3, 4], config=config)
+        assert not handler.handle(actual=[1, 2, 3], expected=[1, 2, 3, 4], config=config)
         assert caplog.messages[0].startswith("objects have different lengths:")
 
 
 def test_same_length_handler_handle_without_next_handler(config: EqualityConfig) -> None:
     handler = SameLengthHandler()
     with pytest.raises(RuntimeError, match="next handler is not defined"):
-        handler.handle(object1=[1, 2, 3], object2=[1, 2, 3], config=config)
+        handler.handle(actual=[1, 2, 3], expected=[1, 2, 3], config=config)
 
 
 def test_same_length_handler_set_next_handler() -> None:
@@ -370,7 +370,7 @@ def test_same_object_handler_handle_false(
 def test_same_object_handler_handle_without_next_handler(config: EqualityConfig) -> None:
     handler = SameObjectHandler()
     with pytest.raises(RuntimeError, match="next handler is not defined"):
-        handler.handle(object1="abc", object2="ABC", config=config)
+        handler.handle(actual="abc", expected="ABC", config=config)
 
 
 def test_same_object_handler_set_next_handler() -> None:
@@ -422,14 +422,14 @@ def test_same_type_handler_handle_false_show_difference(
     config.show_difference = True
     handler = SameTypeHandler()
     with caplog.at_level(logging.INFO):
-        assert not handler.handle(object1=0, object2="abc", config=config)
+        assert not handler.handle(actual=0, expected="abc", config=config)
         assert caplog.messages[0].startswith("objects have different types:")
 
 
 def test_same_type_handler_handle_without_next_handler(config: EqualityConfig) -> None:
     handler = SameTypeHandler()
     with pytest.raises(RuntimeError, match="next handler is not defined"):
-        handler.handle(object1="abc", object2="ABC", config=config)
+        handler.handle(actual="abc", expected="ABC", config=config)
 
 
 def test_same_type_handler_set_next_handler() -> None:

--- a/tests/unit/equality/handlers/test_numpy.py
+++ b/tests/unit/equality/handlers/test_numpy.py
@@ -50,7 +50,7 @@ def test_numpy_array_equal_handler_str() -> None:
 
 @numpy_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (np.ones(shape=(2, 3), dtype=float), np.ones(shape=(2, 3), dtype=float)),
         (np.ones(shape=(2, 3), dtype=int), np.ones(shape=(2, 3), dtype=int)),
@@ -58,14 +58,14 @@ def test_numpy_array_equal_handler_str() -> None:
     ],
 )
 def test_numpy_array_equal_handler_handle_true(
-    object1: np.ndarray, object2: np.ndarray, config: EqualityConfig
+    actual: np.ndarray, expected: np.ndarray, config: EqualityConfig
 ) -> None:
-    assert NumpyArrayEqualHandler().handle(object1, object2, config)
+    assert NumpyArrayEqualHandler().handle(actual, expected, config)
 
 
 @numpy_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (np.ones(shape=(2, 3)), np.ones(shape=(3, 2))),
         (np.ones(shape=(2, 3)), np.ones(shape=(2, 1))),
@@ -73,9 +73,9 @@ def test_numpy_array_equal_handler_handle_true(
     ],
 )
 def test_numpy_array_equal_handler_handle_false(
-    object1: np.ndarray, object2: np.ndarray, config: EqualityConfig
+    actual: np.ndarray, expected: np.ndarray, config: EqualityConfig
 ) -> None:
-    assert not NumpyArrayEqualHandler().handle(object1, object2, config)
+    assert not NumpyArrayEqualHandler().handle(actual, expected, config)
 
 
 @numpy_available
@@ -114,7 +114,7 @@ def test_numpy_array_equal_handler_handle_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert NumpyArrayEqualHandler().handle(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 

--- a/tests/unit/equality/handlers/test_numpy.py
+++ b/tests/unit/equality/handlers/test_numpy.py
@@ -101,7 +101,7 @@ def test_numpy_array_equal_handler_handle_false_show_difference(
     handler = NumpyArrayEqualHandler()
     with caplog.at_level(logging.INFO):
         assert not handler.handle(
-            object1=np.ones(shape=(2, 3)), object2=np.ones(shape=(3, 2)), config=config
+            actual=np.ones(shape=(2, 3)), expected=np.ones(shape=(3, 2)), config=config
         )
         assert caplog.messages[0].startswith("numpy.ndarrays have different elements:")
 
@@ -114,7 +114,7 @@ def test_numpy_array_equal_handler_handle_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert NumpyArrayEqualHandler().handle(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 

--- a/tests/unit/equality/handlers/test_pandas.py
+++ b/tests/unit/equality/handlers/test_pandas.py
@@ -57,7 +57,7 @@ def test_pandas_dataframe_equal_handler_str() -> None:
 
 @pandas_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (pandas.DataFrame({}), pandas.DataFrame({})),
         (pandas.DataFrame({"col": [1, 2, 3]}), pandas.DataFrame({"col": [1, 2, 3]})),
@@ -80,14 +80,14 @@ def test_pandas_dataframe_equal_handler_str() -> None:
     ],
 )
 def test_pandas_dataframe_equal_handler_handle_true(
-    object1: pandas.DataFrame,
-    object2: pandas.DataFrame,
+    actual: pandas.DataFrame,
+    expected: pandas.DataFrame,
     config: EqualityConfig,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     handler = PandasDataFrameEqualHandler()
     with caplog.at_level(logging.INFO):
-        assert handler.handle(object1, object2, config)
+        assert handler.handle(actual, expected, config)
         assert not caplog.messages
 
 
@@ -201,7 +201,7 @@ def test_pandas_dataframe_equal_handler_handle_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert PandasDataFrameEqualHandler().handle(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 
@@ -232,7 +232,7 @@ def test_pandas_series_equal_handler_str() -> None:
 
 @pandas_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (pandas.Series(data=[], dtype=object), pandas.Series(data=[], dtype=object)),
         (pandas.Series(data=[1, 2, 3]), pandas.Series(data=[1, 2, 3])),
@@ -240,14 +240,14 @@ def test_pandas_series_equal_handler_str() -> None:
     ],
 )
 def test_pandas_series_equal_handler_handle_true(
-    object1: pandas.Series,
-    object2: pandas.Series,
+    actual: pandas.Series,
+    expected: pandas.Series,
     config: EqualityConfig,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     handler = PandasSeriesEqualHandler()
     with caplog.at_level(logging.INFO):
-        assert handler.handle(object1, object2, config)
+        assert handler.handle(actual, expected, config)
         assert not caplog.messages
 
 
@@ -361,7 +361,7 @@ def test_pandas_series_equal_handler_handle_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert PandasSeriesEqualHandler().handle(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 

--- a/tests/unit/equality/handlers/test_pandas.py
+++ b/tests/unit/equality/handlers/test_pandas.py
@@ -201,7 +201,7 @@ def test_pandas_dataframe_equal_handler_handle_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert PandasDataFrameEqualHandler().handle(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 
@@ -327,8 +327,8 @@ def test_pandas_series_equal_handler_handle_false_show_difference(
     handler = PandasSeriesEqualHandler()
     with caplog.at_level(logging.INFO):
         assert not handler.handle(
-            object1=pandas.Series(data=[1, 2, 3]),
-            object2=pandas.Series(data=[1, 2, 3, 4]),
+            actual=pandas.Series(data=[1, 2, 3]),
+            expected=pandas.Series(data=[1, 2, 3, 4]),
             config=config,
         )
         assert caplog.messages[0].startswith("pandas.Series have different elements:")
@@ -361,7 +361,7 @@ def test_pandas_series_equal_handler_handle_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert PandasSeriesEqualHandler().handle(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 

--- a/tests/unit/equality/handlers/test_polars.py
+++ b/tests/unit/equality/handlers/test_polars.py
@@ -57,7 +57,7 @@ def test_polars_dataframe_equal_handler_str() -> None:
 
 @polars_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (polars.DataFrame({}), polars.DataFrame({})),
         (polars.DataFrame({"col": [1, 2, 3]}), polars.DataFrame({"col": [1, 2, 3]})),
@@ -80,14 +80,14 @@ def test_polars_dataframe_equal_handler_str() -> None:
     ],
 )
 def test_polars_dataframe_equal_handler_handle_true(
-    object1: polars.DataFrame,
-    object2: polars.DataFrame,
+    actual: polars.DataFrame,
+    expected: polars.DataFrame,
     config: EqualityConfig,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     handler = PolarsDataFrameEqualHandler()
     with caplog.at_level(logging.INFO):
-        assert handler.handle(object1, object2, config)
+        assert handler.handle(actual, expected, config)
         assert not caplog.messages
 
 
@@ -201,7 +201,7 @@ def test_polars_dataframe_equal_handler_handle_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert PolarsDataFrameEqualHandler().handle(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 
@@ -232,7 +232,7 @@ def test_polars_series_equal_handler_str() -> None:
 
 @polars_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (polars.Series([]), polars.Series([])),
         (polars.Series([1, 2, 3]), polars.Series([1, 2, 3])),
@@ -240,14 +240,14 @@ def test_polars_series_equal_handler_str() -> None:
     ],
 )
 def test_polars_series_equal_handler_handle_true(
-    object1: polars.Series,
-    object2: polars.Series,
+    actual: polars.Series,
+    expected: polars.Series,
     config: EqualityConfig,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     handler = PolarsSeriesEqualHandler()
     with caplog.at_level(logging.INFO):
-        assert handler.handle(object1, object2, config)
+        assert handler.handle(actual, expected, config)
         assert not caplog.messages
 
 
@@ -342,7 +342,7 @@ def test_polars_series_equal_handler_handle_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert PolarsSeriesEqualHandler().handle(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 

--- a/tests/unit/equality/handlers/test_polars.py
+++ b/tests/unit/equality/handlers/test_polars.py
@@ -201,7 +201,7 @@ def test_polars_dataframe_equal_handler_handle_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert PolarsDataFrameEqualHandler().handle(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 
@@ -308,8 +308,8 @@ def test_polars_series_equal_handler_handle_false_show_difference(
     handler = PolarsSeriesEqualHandler()
     with caplog.at_level(logging.INFO):
         assert not handler.handle(
-            object1=polars.Series([1, 2, 3]),
-            object2=polars.Series([1, 2, 3, 4]),
+            actual=polars.Series([1, 2, 3]),
+            expected=polars.Series([1, 2, 3, 4]),
             config=config,
         )
         assert caplog.messages[0].startswith("polars.Series have different elements:")
@@ -342,7 +342,7 @@ def test_polars_series_equal_handler_handle_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert PolarsSeriesEqualHandler().handle(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 

--- a/tests/unit/equality/handlers/test_scalar.py
+++ b/tests/unit/equality/handlers/test_scalar.py
@@ -43,7 +43,7 @@ def test_nan_equal_handler_handle_true(config: EqualityConfig) -> None:
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (float("nan"), float("nan")),
         (4.2, 4.2),
@@ -51,9 +51,9 @@ def test_nan_equal_handler_handle_true(config: EqualityConfig) -> None:
     ],
 )
 def test_nan_equal_handler_handle_false(
-    object1: float, object2: float, config: EqualityConfig
+    actual: float, expected: float, config: EqualityConfig
 ) -> None:
-    assert not NanEqualHandler(next_handler=FalseHandler()).handle(object1, object2, config)
+    assert not NanEqualHandler(next_handler=FalseHandler()).handle(actual, expected, config)
 
 
 def test_nan_equal_handler_handle_without_next_handler(config: EqualityConfig) -> None:
@@ -98,32 +98,32 @@ def test_scalar_equal_handler_str() -> None:
 @pytest.mark.parametrize(
     "example",
     [
-        pytest.param(ExamplePair(object1=4, object2=4), id="int"),
-        pytest.param(ExamplePair(object1=4.2, object2=4.2), id="float"),
-        pytest.param(ExamplePair(object1=-1.0, object2=-1.0), id="negative"),
-        pytest.param(ExamplePair(object1=float("inf"), object2=float("inf")), id="infinity"),
-        pytest.param(ExamplePair(object1=float("-inf"), object2=float("-inf")), id="-infinity"),
+        pytest.param(ExamplePair(actual=4, expected=4), id="int"),
+        pytest.param(ExamplePair(actual=4.2, expected=4.2), id="float"),
+        pytest.param(ExamplePair(actual=-1.0, expected=-1.0), id="negative"),
+        pytest.param(ExamplePair(actual=float("inf"), expected=float("inf")), id="infinity"),
+        pytest.param(ExamplePair(actual=float("-inf"), expected=float("-inf")), id="-infinity"),
     ],
 )
 def test_scalar_equal_handler_handle_true(example: ExamplePair, config: EqualityConfig) -> None:
-    assert ScalarEqualHandler().handle(example.object1, example.object2, config)
+    assert ScalarEqualHandler().handle(example.actual, example.expected, config)
 
 
 @pytest.mark.parametrize(
     "example",
     [
-        pytest.param(ExamplePair(object1=0, object2=1), id="different values - int"),
-        pytest.param(ExamplePair(object1=4.0, object2=4.2), id="different values - float"),
-        pytest.param(ExamplePair(object1=float("inf"), object2=4.2), id="different values - inf"),
+        pytest.param(ExamplePair(actual=0, expected=1), id="different values - int"),
+        pytest.param(ExamplePair(actual=4.0, expected=4.2), id="different values - float"),
+        pytest.param(ExamplePair(actual=float("inf"), expected=4.2), id="different values - inf"),
         pytest.param(
-            ExamplePair(object1=float("inf"), object2=float("-inf")), id="opposite infinity"
+            ExamplePair(actual=float("inf"), expected=float("-inf")), id="opposite infinity"
         ),
-        pytest.param(ExamplePair(object1=float("nan"), object2=1.0), id="one nan"),
-        pytest.param(ExamplePair(object1=float("nan"), object2=float("nan")), id="two nans"),
+        pytest.param(ExamplePair(actual=float("nan"), expected=1.0), id="one nan"),
+        pytest.param(ExamplePair(actual=float("nan"), expected=float("nan")), id="two nans"),
     ],
 )
 def test_scalar_equal_handler_handle_false(example: ExamplePair, config: EqualityConfig) -> None:
-    assert not ScalarEqualHandler().handle(example.object1, example.object2, config)
+    assert not ScalarEqualHandler().handle(example.actual, example.expected, config)
 
 
 def test_scalar_equal_handler_handle_false_show_difference(
@@ -149,7 +149,7 @@ def test_scalar_equal_handler_handle_true_tolerance(
 ) -> None:
     config.atol = example.atol
     config.rtol = example.rtol
-    assert ScalarEqualHandler().handle(example.object1, example.object2, config)
+    assert ScalarEqualHandler().handle(example.actual, example.expected, config)
 
 
 def test_scalar_equal_handler_set_next_handler() -> None:

--- a/tests/unit/equality/handlers/test_scalar.py
+++ b/tests/unit/equality/handlers/test_scalar.py
@@ -59,7 +59,7 @@ def test_nan_equal_handler_handle_false(
 def test_nan_equal_handler_handle_without_next_handler(config: EqualityConfig) -> None:
     handler = NanEqualHandler()
     with pytest.raises(RuntimeError, match="next handler is not defined"):
-        handler.handle(object1=42, object2=42, config=config)
+        handler.handle(actual=42, expected=42, config=config)
 
 
 def test_nan_equal_handler_set_next_handler() -> None:
@@ -132,7 +132,7 @@ def test_scalar_equal_handler_handle_false_show_difference(
     config.show_difference = True
     handler = ScalarEqualHandler()
     with caplog.at_level(logging.INFO):
-        assert not handler.handle(object1=1.0, object2=2.0, config=config)
+        assert not handler.handle(actual=1.0, expected=2.0, config=config)
         assert caplog.messages[0].startswith("numbers are not equal:")
 
 

--- a/tests/unit/equality/handlers/test_sequence.py
+++ b/tests/unit/equality/handlers/test_sequence.py
@@ -48,7 +48,7 @@ def test_sequence_same_values_handler_str() -> None:
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ([0, 1, 2], [0, 1, 2]),
         ((0, 1, 2), (0, 1, 2)),
@@ -58,27 +58,27 @@ def test_sequence_same_values_handler_str() -> None:
     ],
 )
 def test_sequence_same_values_handler_handle_true(
-    object1: Sequence, object2: Sequence, config: EqualityConfig
+    actual: Sequence, expected: Sequence, config: EqualityConfig
 ) -> None:
-    assert SequenceSameValuesHandler(next_handler=TrueHandler()).handle(object1, object2, config)
+    assert SequenceSameValuesHandler(next_handler=TrueHandler()).handle(actual, expected, config)
 
 
 @numpy_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ([np.ones((2, 3)), np.zeros(2)], [np.ones((2, 3)), np.zeros(2)]),
         ((np.ones((2, 3)), np.zeros(2)), (np.ones((2, 3)), np.zeros(2))),
     ],
 )
 def test_sequence_same_values_handler_handle_true_numpy(
-    object1: Sequence, object2: Sequence, config: EqualityConfig
+    actual: Sequence, expected: Sequence, config: EqualityConfig
 ) -> None:
-    assert SequenceSameValuesHandler(next_handler=TrueHandler()).handle(object1, object2, config)
+    assert SequenceSameValuesHandler(next_handler=TrueHandler()).handle(actual, expected, config)
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ([1, 2, 3], [1, 2, 4]),
         ((1, 2, 3), (1, 2, 4)),
@@ -86,24 +86,24 @@ def test_sequence_same_values_handler_handle_true_numpy(
     ],
 )
 def test_sequence_same_values_handler_handle_false(
-    object1: Sequence, object2: Sequence, config: EqualityConfig
+    actual: Sequence, expected: Sequence, config: EqualityConfig
 ) -> None:
-    assert not SequenceSameValuesHandler().handle(object1, object2, config)
+    assert not SequenceSameValuesHandler().handle(actual, expected, config)
 
 
 @numpy_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ([np.ones((2, 3)), np.zeros(2)], [np.ones((2, 3)), np.ones(2)]),
         ((np.ones((2, 3)), np.zeros(2)), (np.ones((2, 3)), np.ones(2))),
     ],
 )
 def test_sequence_same_values_handler_handle_false_numpy(
-    object1: Sequence, object2: Sequence, config: EqualityConfig
+    actual: Sequence, expected: Sequence, config: EqualityConfig
 ) -> None:
     assert not SequenceSameValuesHandler(next_handler=TrueHandler()).handle(
-        object1, object2, config
+        actual, expected, config
     )
 
 

--- a/tests/unit/equality/handlers/test_sequence.py
+++ b/tests/unit/equality/handlers/test_sequence.py
@@ -113,14 +113,14 @@ def test_sequence_same_values_handler_handle_false_show_difference(
     config.show_difference = True
     handler = SequenceSameValuesHandler()
     with caplog.at_level(logging.INFO):
-        assert not handler.handle(object1=[1, 2, 3], object2=[1, 2, 4], config=config)
+        assert not handler.handle(actual=[1, 2, 3], expected=[1, 2, 4], config=config)
         assert caplog.messages[-1].startswith("sequences have at least one different value:")
 
 
 def test_sequence_same_values_handler_handle_without_next_handler(config: EqualityConfig) -> None:
     handler = SequenceSameValuesHandler()
     with pytest.raises(RuntimeError, match="next handler is not defined"):
-        handler.handle(object1=[1, 2, 3], object2=[1, 2, 3], config=config)
+        handler.handle(actual=[1, 2, 3], expected=[1, 2, 3], config=config)
 
 
 def test_sequence_same_values_handler_set_next_handler() -> None:

--- a/tests/unit/equality/handlers/test_shape.py
+++ b/tests/unit/equality/handlers/test_shape.py
@@ -102,7 +102,7 @@ def test_same_shape_handler_handle_false_show_difference(
     handler = SameShapeHandler()
     with caplog.at_level(logging.INFO):
         assert not handler.handle(
-            object1=np.ones(shape=(2, 3)), object2=np.ones(shape=(3, 2)), config=config
+            actual=np.ones(shape=(2, 3)), expected=np.ones(shape=(3, 2)), config=config
         )
         assert caplog.messages[0].startswith("objects have different shapes:")
 
@@ -111,7 +111,7 @@ def test_same_shape_handler_handle_false_show_difference(
 def test_same_shape_handler_handle_without_next_handler(config: EqualityConfig) -> None:
     handler = SameShapeHandler()
     with pytest.raises(RuntimeError, match="next handler is not defined"):
-        handler.handle(object1=np.ones(shape=(2, 3)), object2=np.ones(shape=(2, 3)), config=config)
+        handler.handle(actual=np.ones(shape=(2, 3)), expected=np.ones(shape=(2, 3)), config=config)
 
 
 def test_same_shape_handler_set_next_handler() -> None:

--- a/tests/unit/equality/handlers/test_shape.py
+++ b/tests/unit/equality/handlers/test_shape.py
@@ -66,7 +66,7 @@ def test_same_shape_handler_str() -> None:
 
 @numpy_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (np.ones(shape=(2, 3), dtype=float), np.zeros(shape=(2, 3), dtype=int)),
         (np.ones(shape=(2, 3), dtype=int), np.zeros(shape=(2, 3), dtype=bool)),
@@ -74,14 +74,14 @@ def test_same_shape_handler_str() -> None:
     ],
 )
 def test_same_shape_handler_handle_true(
-    object1: np.ndarray, object2: np.ndarray, config: EqualityConfig
+    actual: np.ndarray, expected: np.ndarray, config: EqualityConfig
 ) -> None:
-    assert SameShapeHandler(next_handler=TrueHandler()).handle(object1, object2, config)
+    assert SameShapeHandler(next_handler=TrueHandler()).handle(actual, expected, config)
 
 
 @numpy_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (np.ones(shape=(2, 3)), np.ones(shape=(3, 2))),
         (np.ones(shape=(2, 3)), np.ones(shape=(2, 1))),
@@ -89,9 +89,9 @@ def test_same_shape_handler_handle_true(
     ],
 )
 def test_same_shape_handler_handle_false(
-    object1: np.ndarray, object2: np.ndarray, config: EqualityConfig
+    actual: np.ndarray, expected: np.ndarray, config: EqualityConfig
 ) -> None:
-    assert not SameShapeHandler().handle(object1, object2, config)
+    assert not SameShapeHandler().handle(actual, expected, config)
 
 
 @numpy_available

--- a/tests/unit/equality/handlers/test_torch.py
+++ b/tests/unit/equality/handlers/test_torch.py
@@ -109,7 +109,7 @@ def test_torch_tensor_equal_handler_handle_false_show_difference(
     config.show_difference = True
     handler = TorchTensorEqualHandler()
     with caplog.at_level(logging.INFO):
-        assert not handler.handle(object1=torch.ones(2, 3), object2=torch.ones(3, 2), config=config)
+        assert not handler.handle(actual=torch.ones(2, 3), expected=torch.ones(3, 2), config=config)
         assert caplog.messages[0].startswith("torch.Tensors have different elements:")
 
 
@@ -121,7 +121,7 @@ def test_torch_tensor_equal_handler_handle_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert TorchTensorEqualHandler().handle(
-        object1=example.object1, object2=example.object2, config=config
+        actual=example.object1, expected=example.object2, config=config
     )
 
 
@@ -184,8 +184,8 @@ def test_torch_tensor_same_device_handler_handle_false_show_difference(
     handler = TorchTensorSameDeviceHandler()
     with caplog.at_level(logging.INFO):
         assert not handler.handle(
-            object1=Mock(spec=torch.Tensor, device=torch.device("cpu")),
-            object2=Mock(spec=torch.Tensor, device=torch.device("cuda:0")),
+            actual=Mock(spec=torch.Tensor, device=torch.device("cpu")),
+            expected=Mock(spec=torch.Tensor, device=torch.device("cuda:0")),
             config=config,
         )
         assert caplog.messages[0].startswith("torch.Tensors have different devices:")
@@ -197,7 +197,7 @@ def test_torch_tensor_same_device_handler_handle_without_next_handler(
 ) -> None:
     handler = TorchTensorSameDeviceHandler()
     with pytest.raises(RuntimeError, match="next handler is not defined"):
-        handler.handle(object1=torch.ones(2, 3), object2=torch.ones(2, 3), config=config)
+        handler.handle(actual=torch.ones(2, 3), expected=torch.ones(2, 3), config=config)
 
 
 def test_torch_tensor_same_device_handler_set_next_handler() -> None:

--- a/tests/unit/equality/handlers/test_torch.py
+++ b/tests/unit/equality/handlers/test_torch.py
@@ -55,7 +55,7 @@ def test_torch_tensor_equal_handler_str() -> None:
 
 @torch_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (torch.ones(2, 3, dtype=torch.float), torch.ones(2, 3, dtype=torch.float)),
         (torch.ones(2, 3, dtype=torch.int), torch.ones(2, 3, dtype=torch.int)),
@@ -63,14 +63,14 @@ def test_torch_tensor_equal_handler_str() -> None:
     ],
 )
 def test_torch_tensor_equal_handler_handle_true(
-    object1: torch.Tensor, object2: torch.Tensor, config: EqualityConfig
+    actual: torch.Tensor, expected: torch.Tensor, config: EqualityConfig
 ) -> None:
-    assert TorchTensorEqualHandler().handle(object1, object2, config)
+    assert TorchTensorEqualHandler().handle(actual, expected, config)
 
 
 @torch_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (torch.ones(2, 3), torch.ones(3, 2)),
         (torch.ones(2, 3), torch.ones(2, 1)),
@@ -78,9 +78,9 @@ def test_torch_tensor_equal_handler_handle_true(
     ],
 )
 def test_torch_tensor_equal_handler_handle_false(
-    object1: torch.Tensor, object2: torch.Tensor, config: EqualityConfig
+    actual: torch.Tensor, expected: torch.Tensor, config: EqualityConfig
 ) -> None:
-    assert not TorchTensorEqualHandler().handle(object1, object2, config)
+    assert not TorchTensorEqualHandler().handle(actual, expected, config)
 
 
 @torch_available
@@ -121,7 +121,7 @@ def test_torch_tensor_equal_handler_handle_true_tolerance(
     config.atol = example.atol
     config.rtol = example.rtol
     assert TorchTensorEqualHandler().handle(
-        actual=example.object1, expected=example.object2, config=config
+        actual=example.actual, expected=example.expected, config=config
     )
 
 

--- a/tests/unit/equality/testers/test_default.py
+++ b/tests/unit/equality/testers/test_default.py
@@ -98,11 +98,11 @@ def test_equality_tester_add_comparator_duplicate_exist_ok_false() -> None:
 
 
 def test_equality_tester_equal_true(config: EqualityConfig) -> None:
-    assert EqualityTester().equal(object1=1, object2=1, config=config)
+    assert EqualityTester().equal(actual=1, expected=1, config=config)
 
 
 def test_equality_tester_equal_false(config: EqualityConfig) -> None:
-    assert not EqualityTester().equal(object1=1, object2=2, config=config)
+    assert not EqualityTester().equal(actual=1, expected=2, config=config)
 
 
 def test_equality_tester_has_comparator_true() -> None:
@@ -268,13 +268,13 @@ def test_local_equality_tester_clone() -> None:
 
 def test_local_equality_tester_equal_true(config: EqualityConfig) -> None:
     assert LocalEqualityTester({object: DefaultEqualityComparator()}).equal(
-        object1=1, object2=1, config=config
+        actual=1, expected=1, config=config
     )
 
 
 def test_local_equality_tester_equal_false(config: EqualityConfig) -> None:
     assert not LocalEqualityTester({object: DefaultEqualityComparator()}).equal(
-        object1=1, object2=2, config=config
+        actual=1, expected=2, config=config
     )
 
 

--- a/tests/unit/test_comparison.py
+++ b/tests/unit/test_comparison.py
@@ -34,7 +34,7 @@ def test_objects_are_allclose_false_different_type() -> None:
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (1, 1),
         (0, 0),
@@ -49,9 +49,9 @@ def test_objects_are_allclose_false_different_type() -> None:
     ],
 )
 def test_objects_are_allclose_scalar_true_float(
-    object1: bool | float, object2: bool | float
+    actual: bool | float, expected: bool | float
 ) -> None:
-    assert objects_are_allclose(object1, object2)
+    assert objects_are_allclose(actual, expected)
 
 
 @pytest.mark.parametrize(("value", "atol"), [(1.5, 1.0), (1.05, 1e-1), (1.005, 1e-2)])
@@ -65,7 +65,7 @@ def test_objects_are_allclose_scalar_true_rtol(value: float, rtol: float) -> Non
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (1, 2),
         (1.0, 2.0),
@@ -76,8 +76,8 @@ def test_objects_are_allclose_scalar_true_rtol(value: float, rtol: float) -> Non
         (1.0, True),
     ],
 )
-def test_objects_are_allclose_scalar_false(object1: float, object2: float) -> None:
-    assert not objects_are_allclose(object1, object2, rtol=0.0)
+def test_objects_are_allclose_scalar_false(actual: float, expected: float) -> None:
+    assert not objects_are_allclose(actual, expected, rtol=0.0)
 
 
 @torch_available
@@ -166,14 +166,14 @@ def test_objects_are_allclose_numpy_array_true_rtol(array: np.ndarray, rtol: flo
 
 
 @torch_available
-@pytest.mark.parametrize(("object1", "object2"), [([], []), ((), ()), ([1, 2, 3], [1, 2, 3])])
-def test_objects_are_allclose_sequence_true(object1: Sequence, object2: Sequence) -> None:
-    assert objects_are_allclose(object1, object2)
+@pytest.mark.parametrize(("actual", "expected"), [([], []), ((), ()), ([1, 2, 3], [1, 2, 3])])
+def test_objects_are_allclose_sequence_true(actual: Sequence, expected: Sequence) -> None:
+    assert objects_are_allclose(actual, expected)
 
 
 @torch_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ([torch.ones(2, 3), torch.zeros(2)], [torch.ones(2, 3), torch.zeros(2)]),
         ((torch.ones(2, 3), torch.zeros(2)), (torch.ones(2, 3), torch.zeros(2))),
@@ -183,8 +183,8 @@ def test_objects_are_allclose_sequence_true(object1: Sequence, object2: Sequence
         ),
     ],
 )
-def test_objects_are_allclose_sequence_true_torch(object1: Sequence, object2: Sequence) -> None:
-    assert objects_are_allclose(object1, object2)
+def test_objects_are_allclose_sequence_true_torch(actual: Sequence, expected: Sequence) -> None:
+    assert objects_are_allclose(actual, expected)
 
 
 def test_objects_are_allclose_sequence_false() -> None:
@@ -193,7 +193,7 @@ def test_objects_are_allclose_sequence_false() -> None:
 
 @torch_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ({}, {}),
         (OrderedDict({}), OrderedDict({})),
@@ -211,8 +211,8 @@ def test_objects_are_allclose_sequence_false() -> None:
         ),
     ],
 )
-def test_objects_are_allclose_mapping_true(object1: Mapping, object2: Mapping) -> None:
-    assert objects_are_allclose(object1, object2)
+def test_objects_are_allclose_mapping_true(actual: Mapping, expected: Mapping) -> None:
+    assert objects_are_allclose(actual, expected)
 
 
 def test_objects_are_allclose_mapping_false() -> None:
@@ -220,15 +220,15 @@ def test_objects_are_allclose_mapping_false() -> None:
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [("abc", "abc"), (set(), set()), ({1, 2, 3}, {1, 2, 3})],
 )
-def test_objects_are_allclose_other_types_true(object1: Any, object2: Any) -> None:
-    assert objects_are_allclose(object1, object2)
+def test_objects_are_allclose_other_types_true(actual: Any, expected: Any) -> None:
+    assert objects_are_allclose(actual, expected)
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ("abc", "abcd"),
         (set(), ()),
@@ -236,24 +236,24 @@ def test_objects_are_allclose_other_types_true(object1: Any, object2: Any) -> No
         ({1, 2, 4}, {1, 2, 3}),
     ],
 )
-def test_objects_are_allclose_other_types_false(object1: Any, object2: Any) -> None:
-    assert not objects_are_allclose(object1, object2)
+def test_objects_are_allclose_other_types_false(actual: Any, expected: Any) -> None:
+    assert not objects_are_allclose(actual, expected)
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (float("nan"), float("nan")),
         ([4.2, 2.3, float("nan")], [4.2, 2.3, float("nan")]),
         ([4.2, 2.3, (float("nan"), 2, 3)], [4.2, 2.3, (float("nan"), 2, 3)]),
     ],
 )
-def test_objects_are_allclose_scalar_equal_nan_true(object1: Any, object2: Any) -> None:
-    assert objects_are_allclose(object1, object2, equal_nan=True)
+def test_objects_are_allclose_scalar_equal_nan_true(actual: Any, expected: Any) -> None:
+    assert objects_are_allclose(actual, expected, equal_nan=True)
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (float("nan"), float("nan")),
         (float("nan"), "abc"),
@@ -261,8 +261,8 @@ def test_objects_are_allclose_scalar_equal_nan_true(object1: Any, object2: Any) 
         ([4.2, 2.3, (float("nan"), 2, 3)], [4.2, 2.3, (float("nan"), 2, 3)]),
     ],
 )
-def test_objects_are_allclose_scalar_equal_nan_false(object1: Any, object2: Any) -> None:
-    assert not objects_are_allclose(object1, object2)
+def test_objects_are_allclose_scalar_equal_nan_false(actual: Any, expected: Any) -> None:
+    assert not objects_are_allclose(actual, expected)
 
 
 @numpy_available
@@ -314,7 +314,7 @@ def test_objects_are_equal_false_different_type() -> None:
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (1, 1),
         (0, 0),
@@ -327,12 +327,12 @@ def test_objects_are_equal_false_different_type() -> None:
         (None, None),
     ],
 )
-def test_objects_are_equal_scalar_true(object1: bool | float, object2: bool | float) -> None:
-    assert objects_are_equal(object1, object2)
+def test_objects_are_equal_scalar_true(actual: bool | float, expected: bool | float) -> None:
+    assert objects_are_equal(actual, expected)
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         (1, 2),
         (1.0, 2.0),
@@ -343,8 +343,8 @@ def test_objects_are_equal_scalar_true(object1: bool | float, object2: bool | fl
         (1.0, None),
     ],
 )
-def test_objects_are_equal_scalar_false(object1: bool | float, object2: bool | float) -> None:
-    assert not objects_are_equal(object1, object2)
+def test_objects_are_equal_scalar_false(actual: bool | float, expected: bool | float) -> None:
+    assert not objects_are_equal(actual, expected)
 
 
 @torch_available
@@ -369,7 +369,7 @@ def test_objects_are_equal_numpy_array_false() -> None:
 
 @torch_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ([], []),
         ((), ()),
@@ -381,8 +381,8 @@ def test_objects_are_equal_numpy_array_false() -> None:
         ),
     ],
 )
-def test_objects_are_equal_sequence_true(object1: Sequence, object2: Sequence) -> None:
-    assert objects_are_equal(object1, object2)
+def test_objects_are_equal_sequence_true(actual: Sequence, expected: Sequence) -> None:
+    assert objects_are_equal(actual, expected)
 
 
 def test_objects_are_equal_sequence_false() -> None:
@@ -391,7 +391,7 @@ def test_objects_are_equal_sequence_false() -> None:
 
 @torch_available
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ({}, {}),
         (
@@ -408,8 +408,8 @@ def test_objects_are_equal_sequence_false() -> None:
         ),
     ],
 )
-def test_objects_are_equal_mapping_true(object1: Mapping, object2: Mapping) -> None:
-    assert objects_are_equal(object1, object2)
+def test_objects_are_equal_mapping_true(actual: Mapping, expected: Mapping) -> None:
+    assert objects_are_equal(actual, expected)
 
 
 def test_objects_are_equal_mapping_false() -> None:
@@ -417,19 +417,19 @@ def test_objects_are_equal_mapping_false() -> None:
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ("abc", "abc"),
         (set(), set()),
         ({1, 2, 3}, {1, 2, 3}),
     ],
 )
-def test_objects_are_equal_other_types_true(object1: Any, object2: Any) -> None:
-    assert objects_are_equal(object1, object2)
+def test_objects_are_equal_other_types_true(actual: Any, expected: Any) -> None:
+    assert objects_are_equal(actual, expected)
 
 
 @pytest.mark.parametrize(
-    ("object1", "object2"),
+    ("actual", "expected"),
     [
         ("abc", "abcd"),
         (set(), ()),
@@ -437,8 +437,8 @@ def test_objects_are_equal_other_types_true(object1: Any, object2: Any) -> None:
         ({1, 2, 4}, {1, 2, 3}),
     ],
 )
-def test_objects_are_equal_other_types_false(object1: Any, object2: Any) -> None:
-    assert not objects_are_equal(object1, object2)
+def test_objects_are_equal_other_types_false(actual: Any, expected: Any) -> None:
+    assert not objects_are_equal(actual, expected)
 
 
 @numpy_available


### PR DESCRIPTION
In `objects_are_equal` and `objects_are_allclose`:
- rename `object1` argument to `actual`
- rename `object2` argument to `expected`